### PR TITLE
HMRC-1073 Encrypt id_token in cookie

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ PORT=3005
 AWS_REGION=eu-west-2
 MYOTT_RETURN_URL=http://localhost:3001/subscriptions
 MYOTT_COOKIE_DOMAIN=localhost
+ENCRYPTION_SECRET=myott_encryption_secret

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+ENCRYPTION_SECRET=secret_key

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,0 +1,15 @@
+class EncryptionService
+  def self.encrypt_string(string)
+    new.crypt.encrypt_and_sign(string)
+  end
+
+  def self.decrypt_string(encrypted_string)
+    new.crypt.decrypt_and_verify(encrypted_string)
+  end
+
+  def crypt
+    secret = TradeTariffIdentity.encryption_secret
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key("salt", 32)
+    ActiveSupport::MessageEncryptor.new(key)
+  end
+end

--- a/lib/trade_tariff_identity.rb
+++ b/lib/trade_tariff_identity.rb
@@ -12,4 +12,8 @@ module_function
   def cognito_user_pool_id
     ENV["COGNITO_USER_POOL_ID"]
   end
+
+  def encryption_secret
+    ENV["ENCRYPTION_SECRET"]
+  end
 end

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Passwordless", type: :request do
     allow(TradeTariffIdentity).to receive(:cognito_client).and_return(cognito)
     allow(cognito).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"))
     allow(cognito).to receive(:admin_create_user)
-    allow(cognito).to receive(:initiate_auth).and_return(cognito_auth_object)
+    allow(cognito).to receive(:admin_initiate_auth).and_return(cognito_auth_object)
   end
 
   describe "POST /create" do
@@ -27,9 +27,11 @@ RSpec.describe "Passwordless", type: :request do
       expect(cognito).to have_received(:admin_create_user)
     end
 
-    it "initiates auth" do
+    it "initiates auth with auth params" do
       post passwordless_path, params: { email: }
-      expect(cognito).to have_received(:initiate_auth)
+      expect(cognito).to have_received(:admin_initiate_auth).with(
+        hash_including(auth_parameters: hash_including("USERNAME" => email)),
+      )
     end
 
     it "sets the session email" do
@@ -48,7 +50,7 @@ RSpec.describe "Passwordless", type: :request do
     end
 
     it "redirects to login_path on error" do
-      allow(cognito).to receive(:initiate_auth).and_raise(StandardError.new("Error"))
+      allow(cognito).to receive(:admin_initiate_auth).and_raise(StandardError.new("Error"))
       post passwordless_path, params: { email: }
       expect(response).to redirect_to(login_path)
     end
@@ -86,6 +88,11 @@ RSpec.describe "Passwordless", type: :request do
         allow(cognito).to receive(:admin_update_user_attributes)
       end
 
+      it "sets the consumer id in session" do
+        get callback_passwordless_path, params: { email:, token: "token", consumer: "new_consumer" }
+        expect(session[:consumer_id]).to eq("new_consumer")
+      end
+
       it "responds to auth challenge" do
         get callback_passwordless_path, params: { email:, token: "token" }
         expect(cognito).to have_received(:respond_to_auth_challenge)
@@ -99,11 +106,6 @@ RSpec.describe "Passwordless", type: :request do
       it "sets id_token cookie" do
         get callback_passwordless_path, params: { email:, token: "token" }
         expect(cookies["id_token"]).to be_a(String)
-      end
-
-      it "sets access_token cookie" do
-        get callback_passwordless_path, params: { email:, token: "token" }
-        expect(cookies["access_token"]).to be_a(String)
       end
 
       it "redirects to the consumer's return URL" do

--- a/spec/services/encryption_service_spec.rb
+++ b/spec/services/encryption_service_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe EncryptionService, type: :service do
+  let(:string) { "test_string" }
+  let(:encrypted_string) { described_class.encrypt_string(string) }
+
+  describe ".encrypt_string" do
+    it "returns a string" do
+      expect(encrypted_string).to be_a(String)
+    end
+
+    it "is different to the original string" do
+      expect(encrypted_string).not_to eq(string)
+    end
+  end
+
+  describe ".decrypt_string" do
+    it "decrypts an encrypted string back to the original" do
+      decrypted_string = described_class.decrypt_string(encrypted_string)
+      expect(decrypted_string).to eq(string)
+    end
+
+    it "raises an error if the string cannot be decrypted" do
+      expect {
+        described_class.decrypt_string("invalid_encrypted_string")
+      }.to raise_error(ActiveSupport::MessageEncryptor::InvalidMessage)
+    end
+  end
+end


### PR DESCRIPTION
Encrypts the id_token cookie as it contains PII.
Encryption secret will be shared with consumer applications.

The consumer ID has also been added to the callback link. This allows for better errors if the user opens the link in a different browser.