### PR TITLE
HMRC-1072 Find user API

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,2 @@
 ENCRYPTION_SECRET=secret_key
+API_TOKENS=12345abcde

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -8,20 +8,7 @@ module Api
 
     def authenticate
       authenticate_or_request_with_http_token do |provided_token, _options|
-        api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
-      end
-    end
-
-    def api_tokens
-      @api_tokens ||= read_tokens
-    end
-
-    def read_tokens
-      tokens = TradeTariffIdentity.api_tokens
-      if tokens.present?
-        tokens.split(",").map(&:strip)
-      else
-        []
+        TradeTariffIdentity.api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
       end
     end
   end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,4 +1,28 @@
 module Api
   class ApplicationController < ActionController::Base
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
+    before_action :authenticate, unless: -> { Rails.env.development? }
+
+  private
+
+    def authenticate
+      authenticate_or_request_with_http_token do |provided_token, _options|
+        api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
+      end
+    end
+
+    def api_tokens
+      @api_tokens ||= read_tokens
+    end
+
+    def read_tokens
+      tokens = TradeTariffIdentity.api_tokens
+      if tokens.present?
+        tokens.split(",").map(&:strip)
+      else
+        []
+      end
+    end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  class UsersController < Api::ApplicationController
+    def show
+      user = User.find(params[:id])
+      if user
+        render json: { user: }, status: :ok
+      else
+        render json: { error: "User not found" }, status: :not_found
+      end
+    end
+  end
+end

--- a/app/models/consumer.rb
+++ b/app/models/consumer.rb
@@ -1,6 +1,5 @@
 class Consumer
   include ActiveModel::Model
-  include ActiveModel::Attributes
 
   def self.load(consumer_id)
     return nil unless consumer_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,17 @@
+class User
+  include ActiveModel::Model
+
+  def self.find(username)
+    client = TradeTariffIdentity.cognito_client
+    response = client.admin_get_user({
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      username:,
+    })
+
+    User.new(username:, email: response.user_attributes.find { |attr| attr.name == "email" }&.value)
+  rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+    nil
+  end
+
+  attr_accessor :username, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "healthcheckz" => "rails/health#show", as: :rails_health_check
 
+  namespace :api, defaults: { format: 'json' } do
+    resources :users, only: %i[show]
+  end
+
   resources :sessions, only: %i[index new]
   resource :passwordless, only: %i[create show], controller: :passwordless do
     get "callback", on: :member

--- a/lib/trade_tariff_identity.rb
+++ b/lib/trade_tariff_identity.rb
@@ -18,6 +18,6 @@ module_function
   end
 
   def api_tokens
-    ENV["API_TOKENS"]
+    ENV["API_TOKENS"].to_s.split(",").map(&:strip)
   end
 end

--- a/lib/trade_tariff_identity.rb
+++ b/lib/trade_tariff_identity.rb
@@ -16,4 +16,8 @@ module_function
   def encryption_secret
     ENV["ENCRYPTION_SECRET"]
   end
+
+  def api_tokens
+    ENV["API_TOKENS"]
+  end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    username { SecureRandom.uuid }
+    sequence(:email) { |n| "person#{n}@example.com" }
+  end
+end

--- a/spec/lib/trade_tariff_identity_spec.rb
+++ b/spec/lib/trade_tariff_identity_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TradeTariffIdentity do
+  describe ".api_tokens" do
+    before do
+      allow(ENV).to receive(:[]).with("API_TOKENS").and_return(api_tokens_env)
+    end
+
+    context "when API_TOKENS is set" do
+      let(:api_tokens_env) { "token1, token2, token3" }
+
+      it "returns an array of tokens" do
+        expect(described_class.api_tokens).to eq(%w[token1 token2 token3])
+      end
+    end
+
+    context "when API_TOKENS is not set" do
+      let(:api_tokens_env) { nil }
+
+      it "returns an empty array" do
+        expect(described_class.api_tokens).to eq([])
+      end
+    end
+
+    context "when API_TOKENS contains extra spaces" do
+      let(:api_tokens_env) { " token1 , token2 , token3 " }
+
+      it "returns an array of stripped tokens" do
+        expect(described_class.api_tokens).to eq(%w[token1 token2 token3])
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe ".find" do
+    let(:cognito) { instance_double(Aws::CognitoIdentityProvider::Client) }
+    let(:user_pool_id) { "user_pool_id" }
+    let(:username) { "test_user" }
+    let(:email) { "test_user@example.com" }
+
+    before do
+      allow(TradeTariffIdentity).to receive_messages(
+        cognito_client: cognito,
+        cognito_user_pool_id: user_pool_id,
+      )
+    end
+
+    context "when the user exists" do
+      let(:response) do
+        instance_double(
+          Aws::CognitoIdentityProvider::Types::AdminGetUserResponse,
+          user_attributes: [
+            instance_double(Aws::CognitoIdentityProvider::Types::AttributeType, name: "email", value: email),
+          ],
+        )
+      end
+
+      it "returns a User object with the correct attributes", :aggregate_failures do
+        allow(cognito).to receive(:admin_get_user).with({ user_pool_id:, username: username }).and_return(response)
+
+        user = described_class.find(username)
+
+        expect(user).to be_a(described_class)
+        expect(user.username).to eq(username)
+        expect(user.email).to eq(email)
+      end
+    end
+
+    context "when the user does not exist" do
+      it "returns nil" do
+        allow(cognito).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"))
+
+        user = described_class.find(username)
+
+        expect(user).to be_nil
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,6 +26,8 @@ require "rspec/rails"
 # Rails.root.glob("spec/support/**/*.rb").sort_by(&:to_s).each { |f| require f }
 
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you"re not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
     Rails.root.join("spec/fixtures"),

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Users API", type: :request do
+  describe "GET /api/users/:id" do
+    context "with a valid user" do
+      let(:user) { build(:user) }
+
+      before do
+        allow(User).to receive(:find).with(user.username).and_return(user)
+      end
+
+      it "returns a successful response" do
+        get api_user_path(user.username)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the user details" do
+        get api_user_path(user.username)
+        json_response = JSON.parse(response.body)
+        expect(json_response["user"]["email"]).to eq(user.email)
+      end
+    end
+
+    context "with an invalid user" do
+      before do
+        allow(User).to receive(:find).and_return(nil)
+      end
+
+      it "returns an unsuccessful response" do
+        get api_user_path("invalid_user")
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns the error details" do
+        get api_user_path("invalid_user")
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq("User not found")
+      end
+    end
+  end
+end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -2,39 +2,51 @@ require "rails_helper"
 
 RSpec.describe "Users API", type: :request do
   describe "GET /api/users/:id" do
-    context "with a valid user" do
-      let(:user) { build(:user) }
+    let(:user) { build(:user) }
+    let(:headers) { { Authorization: "Bearer 12345abcde" } }
 
+    context "when authenticated with a valid user" do
       before do
         allow(User).to receive(:find).with(user.username).and_return(user)
       end
 
       it "returns a successful response" do
-        get api_user_path(user.username)
+        get api_user_path(user.username), headers: headers
         expect(response).to have_http_status(:success)
       end
 
       it "returns the user details" do
-        get api_user_path(user.username)
+        get api_user_path(user.username), headers: headers
         json_response = JSON.parse(response.body)
         expect(json_response["user"]["email"]).to eq(user.email)
       end
     end
 
-    context "with an invalid user" do
+    context "when authenticated with an invalid user" do
       before do
         allow(User).to receive(:find).and_return(nil)
       end
 
       it "returns an unsuccessful response" do
-        get api_user_path("invalid_user")
+        get api_user_path("invalid_user"), headers: headers
         expect(response).to have_http_status(:not_found)
       end
 
       it "returns the error details" do
-        get api_user_path("invalid_user")
+        get api_user_path("invalid_user"), headers: headers
         json_response = JSON.parse(response.body)
         expect(json_response["error"]).to eq("User not found")
+      end
+    end
+
+    describe "when not authenticated" do
+      before do
+        allow(User).to receive(:find).with(user.username).and_return(user)
+      end
+
+      it "returns an unauthorized response" do
+        get api_user_path(user.username)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Passwordless", type: :request do
   let(:cognito) { instance_double(Aws::CognitoIdentityProvider::Client) }
-  let(:consumer) { FactoryBot.build(:consumer) }
+  let(:consumer) { build(:consumer) }
   let(:cognito_auth_object) { Struct.new(:session).new("session") }
   let(:email) { "test@email.com" }
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Sessions", type: :request do
     end
 
     context "when valid consumer_id is present" do
-      let(:consumer) { FactoryBot.build(:consumer) }
+      let(:consumer) { build(:consumer) }
 
       before do
         allow(Consumer).to receive(:load).with(consumer.id).and_return(consumer)
@@ -37,7 +37,7 @@ RSpec.describe "Sessions", type: :request do
     end
 
     context "when valid consumer_id is present" do
-      let(:consumer) { FactoryBot.build(:consumer) }
+      let(:consumer) { build(:consumer) }
 
       before do
         allow(Consumer).to receive(:load).with(consumer.id).and_return(consumer)


### PR DESCRIPTION
Adds ability to lookup a user in Cognito based on their username.
The API is secured with a bearer token.

This API is for internal use only and will initially be accessed by trade-tariff-backend