### PR TITLE
Don't encrypt locally

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,3 @@ PORT=3005
 AWS_REGION=eu-west-2
 MYOTT_RETURN_URL=http://localhost:3001/subscriptions
 MYOTT_COOKIE_DOMAIN=localhost
-ENCRYPTION_SECRET=myott_encryption_secret

--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ Go to the [Login page](http://localhost:3005/myott)
 Shows how the login flow interacts with Cognito.
 
 ![Diagram](docs/passwordless_login_flow.png)
+
+### Cognito JWT
+
+When the user is redirected to the service, a Cognito JWT is set as a cookie called `id_token` which
+contains the user's details. In non-development environments the token is encrypted using `ENCRYPTION_SECRET`.
+This needs to be shared with the consuming service.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Shows how the login flow interacts with Cognito.
 
 ### Cognito JWT
 
-When the user is redirected to the service, a Cognito JWT is set as a cookie called `id_token` which
-contains the user's details. In non-development environments the token is encrypted using `ENCRYPTION_SECRET`.
-This needs to be shared with the consuming service.
+When the user is redirected to the service, a Cognito JWT is set as a cookie
+called `id_token` which contains the user's details. In non-development
+environments the token is encrypted using `ENCRYPTION_SECRET`. This needs to
+be shared with the consuming service.

--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -69,7 +69,7 @@ class PasswordlessController < ApplicationController
     })
 
     cookies[:id_token] = {
-      value: EncryptionService.encrypt_string(result.authentication_result.id_token[0]),
+      value: encrypted(result.authentication_result.id_token[0]),
       httponly: true,
       domain: ".#{current_consumer.cookie_domain}",
       expires: 1.day.from_now,
@@ -87,5 +87,13 @@ private
 
   def client
     @client ||= TradeTariffIdentity.cognito_client
+  end
+
+  def encrypted(token)
+    if Rails.env.development?
+      token
+    else
+      EncryptionService.encrypt_string(token)
+    end
   end
 end


### PR DESCRIPTION
To simplify development, the JWT will not be encrypted when running locally.