### PR TITLE
HMRC-1174 Add user group

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,2 @@
 ENCRYPTION_SECRET=secret_key
-API_TOKENS=12345abcde
 MYOTT_BASE_URL=http://example.com/

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -8,7 +8,16 @@ module Api
 
     def authenticate
       authenticate_or_request_with_http_token do |provided_token, _options|
-        TradeTariffIdentity.api_tokens.any? { |token| ActiveSupport::SecurityUtils.secure_compare(provided_token, token) }
+        api_group_token_hash = TradeTariffIdentity.api_tokens.find do |_group, token|
+          ActiveSupport::SecurityUtils.secure_compare(token, provided_token)
+        end
+
+        if api_group_token_hash
+          @group = api_group_token_hash.first
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class UsersController < Api::ApplicationController
     def show
-      user = User.find(params[:id])
+      user = User.find(params[:id], @group)
       if user
         render json: { user: }, status: :ok
       else

--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -17,6 +17,12 @@ class PasswordlessController < ApplicationController
       )
     end
 
+    client.admin_add_user_to_group(
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      username: email,
+      group_name: current_consumer.id,
+    )
+
     # Start custom auth to trigger your Lambda to send the link
     resp = client.admin_initiate_auth(
       user_pool_id: TradeTariffIdentity.cognito_user_pool_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,31 @@
 class User
   include ActiveModel::Model
 
-  def self.find(username)
+  def self.find(username, group = nil)
     client = TradeTariffIdentity.cognito_client
-    response = client.admin_get_user({
-      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
-      username:,
-    })
 
-    User.new(username:, email: response.user_attributes.find { |attr| attr.name == "email" }&.value)
-  rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
-    nil
+    begin
+      arguments = {
+        user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+        username: username,
+      }
+
+      user_response = client.admin_get_user(arguments)
+
+      unless Rails.env.development?
+        groups_response = client.admin_list_groups_for_user(arguments)
+
+        in_group = groups_response.groups.any? { |g| g.group_name == group }
+        return nil unless in_group
+      end
+
+      email = user_response.user_attributes.find { |attr| attr.name == "email" }&.value
+      User.new(username: username, email: email)
+    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+      nil
+    rescue Aws::CognitoIdentityProvider::Errors::ResourceNotFoundException
+      nil
+    end
   end
 
   attr_accessor :username, :email

--- a/lib/trade_tariff_identity.rb
+++ b/lib/trade_tariff_identity.rb
@@ -18,6 +18,6 @@ module_function
   end
 
   def api_tokens
-    ENV["API_TOKENS"].to_s.split(",").map(&:strip)
+    JSON.parse(ENV.fetch("API_TOKENS", "{}"))
   end
 end

--- a/spec/lib/trade_tariff_identity_spec.rb
+++ b/spec/lib/trade_tariff_identity_spec.rb
@@ -3,30 +3,22 @@ require "rails_helper"
 RSpec.describe TradeTariffIdentity do
   describe ".api_tokens" do
     before do
-      allow(ENV).to receive(:[]).with("API_TOKENS").and_return(api_tokens_env)
+      allow(ENV).to receive(:fetch).with("API_TOKENS", "{}").and_return(api_tokens_env)
     end
 
     context "when API_TOKENS is set" do
-      let(:api_tokens_env) { "token1, token2, token3" }
+      let(:api_tokens_env) { '{"token1": "12345", "token2": "67890"}' }
 
-      it "returns an array of tokens" do
-        expect(described_class.api_tokens).to eq(%w[token1 token2 token3])
+      it "returns a hash of tokens" do
+        expect(described_class.api_tokens).to eq({ "token1" => "12345", "token2" => "67890" })
       end
     end
 
     context "when API_TOKENS is not set" do
-      let(:api_tokens_env) { nil }
+      let(:api_tokens_env) { "{}" }
 
-      it "returns an empty array" do
-        expect(described_class.api_tokens).to eq([])
-      end
-    end
-
-    context "when API_TOKENS contains extra spaces" do
-      let(:api_tokens_env) { " token1 , token2 , token3 " }
-
-      it "returns an array of stripped tokens" do
-        expect(described_class.api_tokens).to eq(%w[token1 token2 token3])
+      it "returns an empty hash" do
+        expect(described_class.api_tokens).to eq({})
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe User, type: :model do
     let(:user_pool_id) { "user_pool_id" }
     let(:username) { "test_user" }
     let(:email) { "test_user@example.com" }
+    let(:group) { "test_group" }
 
     before do
       allow(TradeTariffIdentity).to receive_messages(
@@ -14,35 +15,92 @@ RSpec.describe User, type: :model do
       )
     end
 
-    context "when the user exists" do
-      let(:response) do
+    def build_user_attributes
+      [
         instance_double(
-          Aws::CognitoIdentityProvider::Types::AdminGetUserResponse,
-          user_attributes: [
-            instance_double(Aws::CognitoIdentityProvider::Types::AttributeType, name: "email", value: email),
-          ],
-        )
+          Aws::CognitoIdentityProvider::Types::AttributeType,
+          name: "email",
+          value: email,
+        ),
+      ]
+    end
+
+    def build_user_response(attrs = build_user_attributes)
+      instance_double(
+        Aws::CognitoIdentityProvider::Types::AdminGetUserResponse,
+        user_attributes: attrs,
+      )
+    end
+
+    def build_groups_response(group_name)
+      instance_double(
+        Aws::CognitoIdentityProvider::Types::AdminListGroupsForUserResponse,
+        groups: [
+          instance_double(
+            Aws::CognitoIdentityProvider::Types::GroupType,
+            group_name: group_name,
+          ),
+        ],
+      )
+    end
+
+    context "when the user exists and is in the group" do
+      subject(:find_user) { described_class.find(username, group) }
+
+      before do
+        response = build_user_response
+        groups_response = build_groups_response(group)
+        setup_cognito_stubs(response, groups_response)
       end
 
-      it "returns a User object with the correct attributes", :aggregate_failures do
-        allow(cognito).to receive(:admin_get_user).with({ user_pool_id:, username: username }).and_return(response)
+      it "returns a User object with the correct attributes" do
+        expect(find_user).to have_attributes(username: username, email: email)
+      end
+    end
 
-        user = described_class.find(username)
+    context "when the user exists but is not in the group" do
+      subject(:find_user) { described_class.find(username, group) }
 
-        expect(user).to be_a(described_class)
-        expect(user.username).to eq(username)
-        expect(user.email).to eq(email)
+      before do
+        response = build_user_response
+        groups_response = build_groups_response("other_group")
+        setup_cognito_stubs(response, groups_response)
+      end
+
+      it "returns nil" do
+        expect(find_user).to be_nil
       end
     end
 
     context "when the user does not exist" do
-      it "returns nil" do
-        allow(cognito).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"))
+      subject(:find_user) { described_class.find(username, group) }
 
-        user = described_class.find(username)
-
-        expect(user).to be_nil
+      before do
+        expected_args = { user_pool_id: user_pool_id, username: username }
+        allow(cognito).to receive(:admin_get_user)
+          .with(expected_args)
+          .and_raise(
+            Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"),
+          )
       end
+
+      it "returns nil" do
+        expect(find_user).to be_nil
+      end
+    end
+
+    def setup_cognito_stubs(user_response, groups_response)
+      expected_args = {
+        user_pool_id: user_pool_id,
+        username: username,
+      }
+
+      allow(cognito).to receive(:admin_get_user)
+        .with(expected_args)
+        .and_return(user_response)
+      allow(cognito).to receive(:admin_list_groups_for_user)
+        .with(expected_args)
+        .and_return(groups_response)
     end
   end
 end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,13 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "Users API", type: :request do
+  let(:api_tokens) { { "group1" => "12345abcde", "group2" => "other_token" } }
+
+  before do
+    allow(TradeTariffIdentity).to receive(:api_tokens).and_return(api_tokens)
+  end
+
   describe "GET /api/users/:id" do
     let(:user) { build(:user) }
     let(:headers) { { Authorization: "Bearer 12345abcde" } }
 
     context "when authenticated with a valid user" do
       before do
-        allow(User).to receive(:find).with(user.username).and_return(user)
+        allow(User).to receive(:find).with(user.username, "group1").and_return(user)
       end
 
       it "returns a successful response" do

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Passwordless", type: :request do
     allow(TradeTariffIdentity).to receive(:cognito_client).and_return(cognito)
     allow(cognito).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"))
     allow(cognito).to receive(:admin_create_user)
+    allow(cognito).to receive(:admin_add_user_to_group)
     allow(cognito).to receive(:admin_initiate_auth).and_return(cognito_auth_object)
   end
 
@@ -25,6 +26,13 @@ RSpec.describe "Passwordless", type: :request do
     it "creates a new user if not found" do
       post passwordless_path, params: { email: }
       expect(cognito).to have_received(:admin_create_user)
+    end
+
+    it "adds the user to the consumer's group" do
+      post passwordless_path, params: { email: }
+      expect(cognito).to have_received(:admin_add_user_to_group).with(
+        hash_including(group_name: consumer.id),
+      )
     end
 
     it "initiates auth with auth params" do


### PR DESCRIPTION
### Jira link

[HMRC-1174](https://transformuk.atlassian.net/browse/HMRC-1174)

### What?

- When user is created, they are added to the cognito group related to the consumer
- When the API is called to return a user, only users in the related user group are returned

### Why?

I am doing this:

- To enable multiple consumers to use the service
