### PR TITLE
Delete user API

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -8,5 +8,13 @@ module Api
         render json: { error: "User not found" }, status: :not_found
       end
     end
+
+    def destroy
+      if User.destroy(params[:id], @group)
+        render json: { message: "User deleted" }, status: :ok
+      else
+        render json: { error: "Something went wrong" }, status: :internal_server_error
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get "healthcheckz" => "rails/health#show", as: :rails_health_check
 
   namespace :api, defaults: { format: 'json' } do
-    resources :users, only: %i[show]
+    resources :users, only: %i[show destroy]
   end
 
   resources :sessions, only: %i[index new]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,18 +1,49 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  describe ".find" do
-    let(:cognito) { instance_double(Aws::CognitoIdentityProvider::Client) }
-    let(:user_pool_id) { "user_pool_id" }
-    let(:username) { "test_user" }
-    let(:email) { "test_user@example.com" }
-    let(:group) { "test_group" }
+  def build_groups_response(group_name)
+    groups = if group_name
+               [
+                 instance_double(
+                   Aws::CognitoIdentityProvider::Types::GroupType,
+                   group_name: group_name,
+                 ),
+               ]
+             else
+               []
+             end
 
-    before do
-      allow(TradeTariffIdentity).to receive_messages(
-        cognito_client: cognito,
-        cognito_user_pool_id: user_pool_id,
-      )
+    instance_double(
+      Aws::CognitoIdentityProvider::Types::AdminListGroupsForUserResponse,
+      groups: groups,
+    )
+  end
+
+  let(:cognito) { instance_double(Aws::CognitoIdentityProvider::Client) }
+  let(:user_pool_id) { "user_pool_id" }
+  let(:username) { "test_user" }
+  let(:group) { "test_group" }
+
+  before do
+    allow(TradeTariffIdentity).to receive_messages(
+      cognito_client: cognito,
+      cognito_user_pool_id: user_pool_id,
+    )
+  end
+
+  describe ".find" do
+    def setup_cognito_stubs(user_response, groups_response)
+      expected_args = {
+        user_pool_id: user_pool_id,
+        username: username,
+      }
+
+      allow(cognito).to receive(:admin_get_user)
+        .with(expected_args)
+        .and_return(user_response)
+      allow(cognito).to receive(:admin_list_groups_for_user)
+        .with(expected_args)
+        .and_return(groups_response)
     end
 
     def build_user_attributes
@@ -32,17 +63,7 @@ RSpec.describe User, type: :model do
       )
     end
 
-    def build_groups_response(group_name)
-      instance_double(
-        Aws::CognitoIdentityProvider::Types::AdminListGroupsForUserResponse,
-        groups: [
-          instance_double(
-            Aws::CognitoIdentityProvider::Types::GroupType,
-            group_name: group_name,
-          ),
-        ],
-      )
-    end
+    let(:email) { "test_user@example.com" }
 
     context "when the user exists and is in the group" do
       subject(:find_user) { described_class.find(username, group) }
@@ -88,19 +109,102 @@ RSpec.describe User, type: :model do
         expect(find_user).to be_nil
       end
     end
+  end
 
-    def setup_cognito_stubs(user_response, groups_response)
+  describe ".destroy" do
+    subject(:destroy_user) { described_class.destroy(username, group) }
+
+    def setup_cognito_stubs(other_group)
       expected_args = {
         user_pool_id: user_pool_id,
         username: username,
       }
 
-      allow(cognito).to receive(:admin_get_user)
+      allow(cognito).to receive(:admin_delete_user)
         .with(expected_args)
-        .and_return(user_response)
       allow(cognito).to receive(:admin_list_groups_for_user)
         .with(expected_args)
-        .and_return(groups_response)
+        .and_return(build_groups_response(other_group))
+      allow(cognito).to receive(:admin_remove_user_from_group)
+        .with(expected_args.merge(group_name: group))
+    end
+
+    context "when the user exists and is only in this group" do
+      before do
+        setup_cognito_stubs(nil)
+      end
+
+      it "removes the user from the group" do
+        destroy_user
+        expect(cognito).to have_received(:admin_remove_user_from_group)
+          .with(hash_including(group_name: group))
+      end
+
+      it "deletes the user" do
+        destroy_user
+        expect(cognito).to have_received(:admin_delete_user)
+          .with(hash_including(username: username))
+      end
+
+      it "returns true after successfully removing the user from the group and deleting the user" do
+        expect(destroy_user).to be true
+      end
+    end
+
+    context "when the user exists and is also in another group" do
+      before do
+        setup_cognito_stubs("other_group")
+      end
+
+      it "removes the user from the group" do
+        destroy_user
+        expect(cognito).to have_received(:admin_remove_user_from_group)
+          .with(hash_including(group_name: group))
+      end
+
+      it "does not delete the user" do
+        destroy_user
+        expect(cognito).not_to have_received(:admin_delete_user)
+      end
+
+      it "returns true" do
+        expect(destroy_user).to be true
+      end
+    end
+
+    context "when the user does not exist" do
+      before do
+        setup_cognito_stubs(nil)
+        allow(cognito).to receive(:admin_list_groups_for_user)
+          .and_raise(
+            Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new(nil, "User not found"),
+          )
+      end
+
+      it "returns true without performing any actions" do
+        expect(destroy_user).to be true
+      end
+    end
+
+    context "when a service error occurs during deletion" do
+      before do
+        allow(cognito).to receive(:admin_list_groups_for_user)
+          .and_return(build_groups_response(group))
+        allow(cognito).to receive(:admin_remove_user_from_group)
+          .and_raise(
+            Aws::CognitoIdentityProvider::Errors::ServiceError.new(nil, "Service error"),
+          )
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "logs the error" do
+        destroy_user
+        expect(Rails.logger).to have_received(:error).with(/Failed to delete user/)
+      end
+
+      it "returns false" do
+        expect(destroy_user).to be false
+      end
     end
   end
 end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -56,4 +56,38 @@ RSpec.describe "Users API", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/users/:id" do
+    let(:headers) { { Authorization: "Bearer 12345abcde" } }
+    let(:username) { "test_user" }
+
+    context "when request is successful" do
+      before do
+        allow(User).to receive(:destroy).with(username, "group1").and_return(true)
+      end
+
+      it "returns a successful response" do
+        delete api_user_path(username), headers: headers
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when request causes an error" do
+      before do
+        allow(User).to receive(:destroy).with(username, "group1").and_return(false)
+      end
+
+      it "returns an unsuccessful response" do
+        delete api_user_path(username), headers: headers
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+
+    describe "when not authenticated" do
+      it "returns an unauthorized response" do
+        delete api_user_path(username)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -18,8 +18,11 @@ data "aws_iam_policy_document" "task" {
     actions = [
       "cognito-idp:AdminAddUserToGroup",
       "cognito-idp:AdminCreateUser",
+      "cognito-idp:AdminDeleteUser",
       "cognito-idp:AdminGetUser",
       "cognito-idp:AdminInitiateAuth",
+      "cognito-idp:AdminListGroupsForUser",
+      "cognito-idp:AdminRemoveUserFromGroup",
       "cognito-idp:AdminUpdateUserAttributes",
     ]
     resources = [data.aws_cognito_user_pool.this.arn]


### PR DESCRIPTION
### Jira link

[HMRC-1146](https://transformuk.atlassian.net/browse/HMRC-1146)

### What?

Added API for deleting user in cognito
User is removed from the provided user group and only fully deleted if they are no longer a member of a group

### Why?

I am doing this because:

We do not want to store user details unnecessarily
