### PR TITLE
Update email regex

### DIFF
--- a/app/models/passwordless_form.rb
+++ b/app/models/passwordless_form.rb
@@ -2,6 +2,8 @@ class PasswordlessForm
   include ActiveModel::Model
   attr_accessor :email
 
+  EMAIL_REGEX = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+
   validates :email, presence: { message: "Enter an email address in the correct format, like name@example.com" },
-                    format: { with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com" }
+                    format: { with: EMAIL_REGEX, message: "Enter an email address in the correct format, like name@example.com" }
 end

--- a/spec/models/passwordless_form_spec.rb
+++ b/spec/models/passwordless_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PasswordlessForm, type: :model do
       end
 
       it "is invalid with an incorrectly formatted email" do
-        form = described_class.new(email: "invalid-email")
+        form = described_class.new(email: "invalid@email")
         expect(form).not_to be_valid
       end
 


### PR DESCRIPTION
### Jira link

[HMRC-1291](https://transformuk.atlassian.net/browse/HMRC-1291)

### What?

Validation allowed emails without a dot in the domain name to pass validation. This new regex does not.

### Why?

I am doing this:

- to avoid users entering invalid email addresses and not getting an appropriate error.
