### PR TITLE
HMRC-1306: Disable tests for now

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       app-name: tariff-identity
       environment: development
+      test-flavour: none
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Jira link

[HMRC-1306](https://transformuk.atlassian.net/browse/HMRC-1306)

### What?

I have added/removed/altered:

- [x] Disable e2e tests in development

### Why?

I am doing this because:

- This environment won't be fully available just by the deployment workflow
