### PR TITLE
HMRC-1446: Migrate tf backend locking to use_lockfile 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 ruby 3.4.4
+terraform 1.12.2

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers

--- a/terraform/backends/production.tfbackend
+++ b/terraform/backends/production.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-production-382373577178"
 key            = "identity.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "identity-lock-382373577178"
+use_lockfile   = true

--- a/terraform/backends/staging.tfbackend
+++ b/terraform/backends/staging.tfbackend
@@ -2,4 +2,4 @@ bucket         = "terraform-state-staging-451934005581"
 key            = "identity.tfstate"
 region         = "eu-west-2"
 encrypt        = true
-dynamodb_table = "identity-lock-451934005581"
+use_lockfile   = true

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.11"
+  required_version = ">=1.12"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Jira link

[HMRC-1446](https://transformuk.atlassian.net/browse/HMRC-1446)

### What?

I have added/removed/altered:

- [x] Removed dynamodb_table from backend config in staging and prod
- [x] Added use_lockfile = true to enable locking with native support in staging and prod
- [x] Upgraded terraform version

### Why?

I am doing this because:

- Terraform has deprecated dynamodb_table in favour of use_lockfile

#### References

[Terraform S3 backend documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3)