### PR TITLE
Handle no consumer better

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_consumer
 
   def current_consumer
-    @current_consumer ||= begin
-      consumer = Consumer.load(consumer_id)
-
-      raise ActionController::BadRequest unless consumer
-
-      consumer
-    end
+    @current_consumer ||= Consumer.load(consumer_id)
   end
 
 private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  before_action :check_consumer
+
   def index
     session[:consumer_id] = current_consumer.id
     redirect_to login_path
@@ -8,5 +10,11 @@ class SessionsController < ApplicationController
     if current_consumer.passwordless?
       @passwordless = PasswordlessForm.new
     end
+  end
+
+private
+
+  def check_consumer
+    redirect_to "/400" and return if current_consumer.nil?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,11 @@ Rails.application.routes.draw do
 
   match "/400", to: "errors#bad_request", via: :all
   match "/404", to: "errors#not_found", via: :all
-  match "*consumer_id", to: "sessions#index", via: :all
+
+  TradeTariffIdentity::CONSUMERS&.each do |consumer|
+    consumer_id = consumer[:id]
+    get consumer_id, to: "sessions#index", defaults: { consumer_id: }
+  end
 
   root to: "sessions#index"
 end

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe "Passwordless", type: :request do
 
   describe "GET /callback" do
     context "when link is correct and used in a timely manner" do
+      let(:consumer) { build(:consumer) }
       let(:authentication_result) { Struct.new(:id_token).new("id_token") }
       let(:cognito_auth_object) { Struct.new(:authentication_result).new(authentication_result) }
 
@@ -102,7 +103,7 @@ RSpec.describe "Passwordless", type: :request do
       end
 
       it "sets the consumer id in session" do
-        allow(Consumer).to receive(:load).with("new_consumer")
+        allow(Consumer).to receive(:load).with("new_consumer").and_return(consumer)
         get callback_passwordless_path, params: { email:, token: "token", consumer: "new_consumer" }
         expect(session[:consumer_id]).to eq("new_consumer")
       end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Sessions", type: :request do
     context "when consumer_id is not present" do
       it "causes an error" do
         get sessions_path
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to redirect_to("/400")
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe "Sessions", type: :request do
     context "when consumer_id is not present" do
       it "causes an error" do
         get sessions_path
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to redirect_to("/400")
       end
     end
 


### PR DESCRIPTION
### What?

Currently an exception is raised unless a valid consumer ID is provided.

- The valid entry routes with the known consumer IDs are now created dynamically.
- Any unknown path is handled as a 404.
- Valid paths without a consumer_id being set are redirected to an error page.
