### PR TITLE
PRDEX-162: Explicitly set urls in the environment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,6 @@
+ADMIN_URL=http://localhost:3003
 AWS_REGION=eu-west-2
-MYOTT_BASE_URL=http://localhost:3001
 MYOTT_COOKIE_DOMAIN=localhost
+MYOTT_URL=http://localhost:3001
 PORT=3005
+PORTAL_URL=http://localhost:3004

--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,7 @@
+ADMIN_URL=http://localhost:3003
+AWS_REGION=eu-west-2
 ENCRYPTION_SECRET=secret_key
-MYOTT_BASE_URL=http://example.com/
+MYOTT_COOKIE_DOMAIN=localhost
+MYOTT_URL=http://localhost:3001
+PORT=3005
+PORTAL_URL=http://localhost:3004

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ RUN bundle install --jobs=4 --no-binstubs
 # Copy all files to /app (except what is defined in .dockerignore)
 COPY . /app/
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=secret bundle exec rails assets:precompile
+RUN \
+  ADMIN_URL=http://localhost:3003 \
+  MYOTT_URL=http://localhost:3001 \
+  PORTAL_URL=http://localhost:3004 \
+  bundle exec rails assets:precompile
 
-# Cleanup to save space in the production image
-RUN rm -rf node_modules log tmp && \
+  # Cleanup to save space in the production image
+  RUN rm -rf node_modules log tmp && \
   rm -rf /usr/local/bundle/cache && \
   rm -rf .env && \
   find /usr/local/bundle/gems -name "*.c" -delete && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+IMAGE_NAME := trade-tariff-identity
+COMMON_ENV := --env-file ".env.development"
+
+default: build run
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+run:
+	docker run \
+		--network=host \
+		--rm \
+		--name $(IMAGE_NAME) \
+		$(COMMON_ENV) \
+		$(IMAGE_NAME)
+
+clean:
+	docker rmi $(IMAGE_NAME)
+
+shell:
+	docker run \
+		--rm \
+		--name $(IMAGE_NAME)-shell \
+		$(COMMON_ENV) \
+		--no-healthcheck \
+		-it $(IMAGE_NAME) /bin/sh

--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -85,7 +85,7 @@ class PasswordlessController < ApplicationController
     cookies[:id_token] = {
       value: encrypted(result.authentication_result.id_token),
       httponly: true,
-      domain: ".#{TradeTariffIdentity.cookie_domain}",
+      domain: ".#{current_consumer.cookie_domain}",
       expires: 1.day.from_now,
     }
 

--- a/app/models/consumer.rb
+++ b/app/models/consumer.rb
@@ -14,7 +14,7 @@ class Consumer
         methods: consumer_attributes[:methods],
         success_url: consumer_attributes[:success_url],
         failure_url: consumer_attributes[:failure_url],
-        cookie_domain: consumer_attributes[:cookie_domain])
+        cookie_domain: TradeTariffIdentity.cookie_domain)
   end
 
   attr_accessor :id, :methods, :success_url, :failure_url, :cookie_domain

--- a/config/consumers.yml
+++ b/config/consumers.yml
@@ -1,34 +1,34 @@
 # MyOTT Subscriptions
 development:
   - id: myott
-    success_url: http://localhost:3001/subscriptions
-    failure_url: http://localhost:3001/subscriptions/invalid
+    success_url: <%= URI.join(ENV["MYOTT_URL"], "/subscriptions").to_s %>
+    failure_url: <%= URI.join(ENV["MYOTT_URL"], "/subscriptions/invalid").to_s %>
     methods:
       - :passwordless
   - id: portal
-    success_url: http://localhost:3000/
-    failure_url: http://localhost:3000/users/invalid
+    success_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/").to_s %>
+    failure_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
   - id: admin
-    success_url: http://localhost:3003/
-    failure_url: http://localhost:3003/users/invalid
+    success_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/").to_s %>
+    failure_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
 
 production:
   - id: <%= ENV.fetch("MYOTT_ID", "") %>
-    success_url: <%= URI.join(ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk"), "/subscriptions").to_s %>
-    failure_url: <%= URI.join(ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk"), "/subscriptions/invalid").to_s %>
+    success_url: <%= URI.join(ENV["MYOTT_URL"], "/subscriptions").to_s %>
+    failure_url: <%= URI.join(ENV["MYOTT_URL"], "/subscriptions/invalid").to_s %>
     methods:
       - :passwordless
   - id: portal
-    success_url: <%= URI.join("hub", ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk").sub("www.", ""), "/").to_s %>
-    failure_url: <%= URI.join("hub", ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk").sub("www.", ""), "/users/invalid").to_s %>
+    success_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/").to_s %>
+    failure_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
   - id: admin
-    success_url: <%= URI.join("admin", ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk").sub("www.", ""), "/").to_s %>
-    failure_url: <%= URI.join("admin", ENV.fetch("MYOTT_BASE_URL", "https://www.trade-tariff.service.gov.uk").sub("www.", ""), "/users/invalid").to_s %>
+    success_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/").to_s %>
+    failure_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless

--- a/config/consumers.yml
+++ b/config/consumers.yml
@@ -6,13 +6,13 @@ development:
     methods:
       - :passwordless
   - id: portal
-    success_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/").to_s %>
-    failure_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/users/invalid").to_s %>
+    success_url: <%= ENV["PORTAL_URL"].to_s %>
+    failure_url: <%= URI.join(ENV["PORTAL_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
   - id: admin
-    success_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/").to_s %>
-    failure_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/users/invalid").to_s %>
+    success_url: <%= ENV["ADMIN_URL"].to_s %>
+    failure_url: <%= URI.join(ENV["ADMIN_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
 
@@ -23,12 +23,12 @@ production:
     methods:
       - :passwordless
   - id: portal
-    success_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/").to_s %>
-    failure_url: <%= URI.join("hub", ENV["PORTAL_URL"], "/users/invalid").to_s %>
+    success_url: <%= ENV["PORTAL_URL"] %>
+    failure_url: <%= URI.join(ENV["PORTAL_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless
   - id: admin
-    success_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/").to_s %>
-    failure_url: <%= URI.join("admin", ENV["ADMIN_URL"], "/users/invalid").to_s %>
+    success_url: <%= ENV["ADMIN_URL"].to_s %>
+    failure_url: <%= URI.join(ENV["ADMIN_URL"], "/users/invalid").to_s %>
     methods:
       - :passwordless

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "healthcheckz" => "rails/health#show", as: :rails_health_check
 
   namespace :api, defaults: { format: 'json' } do


### PR DESCRIPTION
### Jira link

[PRDEX-162](https://transformuk.atlassian.net/browse/PRDEX-162)

### What?

I have added/removed/altered:

- [x] Added explicit environment variables for success/failure urls across all consumer groups

### Why?

I am doing this because:

- This avoids confusingly manipulating the different success/failure urls called after a successful/invalid login and is just much simpler
