### PR TITLE
HMRC-1965: Remove HTTP fallback and tighten security groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /app
 
 ENV RAILS_SERVE_STATIC_FILES=true \
   RAILS_ENV=production \
-  PORT=8080
+  SSL_PORT=8443
 
 RUN bundle config set without 'development test'
 
@@ -61,9 +61,8 @@ RUN addgroup -S tariff && \
   chown -R tariff:tariff /app && \
   chown -R tariff:tariff /usr/local/bundle
 
-HEALTHCHECK CMD nc -z 0.0.0.0 $PORT
+HEALTHCHECK CMD nc -z 0.0.0.0 $SSL_PORT
 
 USER tariff
 
-#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -28,7 +28,9 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Explicit HTTP bind,  default is 3000.
-bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
+if Rails.env.development?
+  bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
+end
 
 # Explicit HTTPS bind
 cert = ENV['SSL_CERT_PEM']&.gsub("\\n", "\n")

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,8 +27,10 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
+rails_env = ENV.fetch("RAILS_ENV", "development")
+
 # Explicit HTTP bind,  default is 3000.
-if Rails.env.development?
+if rails_env == "development"
   bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 3000)}"
 end
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,7 +30,6 @@
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
-| [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -13,10 +13,6 @@ data "aws_subnets" "private" {
   }
 }
 
-data "aws_lb_target_group" "this" {
-  name = "identity"
-}
-
 data "aws_lb_target_group" "this_https" {
   name = "identity-https"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,16 +10,8 @@ module "service" {
   subnet_ids      = data.aws_subnets.private.ids
   security_groups = [data.aws_security_group.this.id]
 
-  target_group_mappings = [
-    {
-      target_group_arn = data.aws_lb_target_group.this.arn
-      container_port   = 8080
-    },
-    {
-      target_group_arn = data.aws_lb_target_group.this_https.arn
-      container_port   = 8443
-    },
-  ]
+  target_group_arn = data.aws_lb_target_group.this_https.arn
+  container_port   = 8443
 
   cloudwatch_log_group_name = "platform-logs-${var.environment}"
 


### PR DESCRIPTION
# Jira link
[HMRC-1965](https://transformuk.atlassian.net/browse/HMRC-1965)

## What?
Remove the HTTP listener from all services and close port 8080 in security groups. After this, only encrypted HTTPS traffic reaches the containers.

I have:

- Update config/puma.rb to restrict the HTTP port bind only to development - only keep ssl_bind on 8443
- Update Dockerfile HEALTHCHECK to check port 8443
- Update PORT environment variable to 8443

## Why?

I am doing this because:

- Only encrypted HTTPS traffic allowed in ecs cluster
