### PR TITLE
Refactor: Extract TokenService for token exchange

### DIFF
--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -41,16 +41,13 @@ class PasswordlessController < ApplicationController
       render :invalid and return
     end
 
-    response = cognito.respond_to_custom_challenge(
-      session: auth,
-      username: email,
-      answer: token,
-    )
+    token_service = TokenService.new
+    result = token_service.exchange_challenge(session: auth, username: email, answer: token)
 
     # Set email as verified
-    cognito.update_user_attributes(email, [{ name: "email_verified", value: "true" }])
+    token_service.verify_email(email)
 
-    set_cookies(response.authentication_result)
+    set_cookies(result)
 
     redirect_to current_consumer.success_url, allow_other_host: true
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,12 +39,8 @@ private
     return false if cookies[refresh_token_cookie_name].blank?
 
     begin
-      response = CognitoServiceAdapter.new.initiate_refresh_token_auth(
-        cookies[refresh_token_cookie_name],
-      )
-
-      set_cookies(response.authentication_result)
-
+      result = TokenService.new.refresh(cookies[refresh_token_cookie_name])
+      set_cookies(result)
       true
     rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
       clear_cookies

--- a/app/services/token_service.rb
+++ b/app/services/token_service.rb
@@ -1,0 +1,21 @@
+class TokenService
+  def initialize(cognito: CognitoServiceAdapter.new)
+    @cognito = cognito
+  end
+
+  def refresh(refresh_token)
+    @cognito.initiate_refresh_token_auth(refresh_token).authentication_result
+  end
+
+  def exchange_challenge(session:, username:, answer:)
+    @cognito.respond_to_custom_challenge(
+      session:,
+      username:,
+      answer:,
+    ).authentication_result
+  end
+
+  def verify_email(username)
+    @cognito.update_user_attributes(username, [{ name: "email_verified", value: "true" }])
+  end
+end


### PR DESCRIPTION
## What

Extracts a new `TokenService` class encapsulating all Cognito token-exchange operations.

## Why

Both `SessionsController#refresh_session_with_token` and `PasswordlessController#callback` were independently building Cognito clients and constructing token-exchange requests. Any change to how token exchange works had to be made in two places.

## Changes

- New: `app/services/token_service.rb` — `refresh`, `exchange_challenge`, `verify_email`
- Updated: `app/controllers/sessions_controller.rb` — delegates to `TokenService#refresh`
- Updated: `app/controllers/passwordless_controller.rb` — delegates to `TokenService#exchange_challenge` + `#verify_email`

## Testing

121 examples, 0 failures.