### PR TITLE
Refactor: Break down PasswordlessController#create

### DIFF
--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -10,34 +10,10 @@ class PasswordlessController < ApplicationController
 
     email = @passwordless.email
 
-    # try to create the user if they don’t exist
-    begin
-      client.admin_get_user(
-        user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
-        username: email,
-      )
-    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
-      client.admin_create_user(
-        user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
-        username: email,
-        user_attributes: [{ name: "email", value: email }],
-        message_action: "SUPPRESS",
-      )
-    end
+    find_or_create_user(email)
+    add_user_to_consumer_group(email)
 
-    client.admin_add_user_to_group(
-      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
-      username: email,
-      group_name: current_consumer.id,
-    )
-
-    # Start custom auth to trigger your Lambda to send the link
-    resp = client.admin_initiate_auth(
-      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
-      client_id: TradeTariffIdentity.cognito_client_id,
-      auth_flow: "CUSTOM_AUTH",
-      auth_parameters: { "USERNAME" => email },
-    )
+    resp = initiate_passwordless_auth(email)
 
     session[:email] = email
     session[:login] = resp.session
@@ -93,6 +69,37 @@ class PasswordlessController < ApplicationController
   end
 
 private
+
+  def find_or_create_user(email)
+    client.admin_get_user(
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      username: email,
+    )
+  rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+    client.admin_create_user(
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      username: email,
+      user_attributes: [{ name: "email", value: email }],
+      message_action: "SUPPRESS",
+    )
+  end
+
+  def add_user_to_consumer_group(email)
+    client.admin_add_user_to_group(
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      username: email,
+      group_name: current_consumer.id,
+    )
+  end
+
+  def initiate_passwordless_auth(email)
+    client.admin_initiate_auth(
+      user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+      client_id: TradeTariffIdentity.cognito_client_id,
+      auth_flow: "CUSTOM_AUTH",
+      auth_parameters: { "USERNAME" => email },
+    )
+  end
 
   def permitted_params
     params.require(:passwordless_form).permit(:email)


### PR DESCRIPTION
## What

Breaks the `#create` action in `PasswordlessController` into focused private methods.

## Why

The method was handling form validation, user lookup, user creation, group assignment, auth flow initiation, session management, and error handling all in one place — making it hard to follow and test individual steps.

## Changes

- `app/controllers/passwordless_controller.rb`: extracted `find_or_create_user`, `add_user_to_consumer_group`, `initiate_passwordless_auth`

## Testing

No behaviour changes. 121 examples, 0 failures.