### PR TITLE
OTTIMP-501 Use unprocessable_content

### DIFF
--- a/app/controllers/api/client_credentials_controller.rb
+++ b/app/controllers/api/client_credentials_controller.rb
@@ -59,7 +59,7 @@ module Api
   private
 
     def invalid_parameter(exception)
-      render json: { error: "Invalid request: #{exception.message}" }, status: :unprocessable_entity
+      render json: { error: "Invalid request: #{exception.message}" }, status: :unprocessable_content
     end
 
     def cognito_service_error(exception)

--- a/spec/requests/client_credentials_spec.rb
+++ b/spec/requests/client_credentials_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Client credentials API", type: :request do
       it "returns 422" do
         post "/api/client_credentials", params: { scopes: ["tariff/read"] }.to_json, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns error message in body" do


### PR DESCRIPTION
### Jira link

[OTTIMP-501](https://transformuk.atlassian.net/browse/OTTIMP-501)

### What?

Rack has deprecated the symbol 'unprocessable_entity' for HTTP status 422. It has been replaced by `unprocessable_content`.
