### PR TITLE
OTTIMP-542 Enable refresh token renewal

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,19 +16,19 @@ class ApplicationController < ActionController::Base
     cookies.delete(refresh_token_cookie_name, domain: current_consumer.cookie_domain)
   end
 
-  def set_cookies(result)
-    return if result.blank?
+  def set_cookies(tokens)
+    return if tokens.blank?
 
     cookies[id_token_cookie_name] = {
-      value: encrypted(result.id_token),
+      value: encrypted(tokens.id_token),
       httponly: true,
       domain: current_consumer.cookie_domain,
       expires: COOKIE_DURATION.from_now,
     }
 
-    if result.refresh_token.present?
+    if tokens.refresh_token.present?
       cookies[refresh_token_cookie_name] = {
-        value: result.refresh_token,
+        value: tokens.refresh_token,
         httponly: true,
         domain: current_consumer.cookie_domain,
         expires: COOKIE_DURATION.from_now,

--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -42,12 +42,12 @@ class PasswordlessController < ApplicationController
     end
 
     token_service = TokenService.new
-    result = token_service.exchange_challenge(session: auth, username: email, answer: token)
+    tokens = token_service.exchange_challenge(session: auth, username: email, answer: token)
 
     # Set email as verified
     token_service.verify_email(email)
 
-    set_cookies(result)
+    set_cookies(tokens)
 
     redirect_to current_consumer.success_url, allow_other_host: true
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,8 +39,8 @@ private
     return false if cookies[refresh_token_cookie_name].blank?
 
     begin
-      result = TokenService.new.refresh(cookies[refresh_token_cookie_name])
-      set_cookies(result)
+      tokens = TokenService.new.refresh(cookies[refresh_token_cookie_name])
+      set_cookies(tokens)
       true
     rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
       clear_cookies

--- a/app/services/cognito_service_adapter.rb
+++ b/app/services/cognito_service_adapter.rb
@@ -45,12 +45,10 @@ class CognitoServiceAdapter
     )
   end
 
-  def initiate_refresh_token_auth(refresh_token)
-    @client.admin_initiate_auth(
-      user_pool_id: @user_pool_id,
+  def refresh_tokens(refresh_token)
+    @client.get_tokens_from_refresh_token(
       client_id: client_id,
-      auth_flow: "REFRESH_TOKEN_AUTH",
-      auth_parameters: { "REFRESH_TOKEN" => refresh_token },
+      refresh_token:,
     )
   end
 

--- a/app/services/token_service.rb
+++ b/app/services/token_service.rb
@@ -4,7 +4,7 @@ class TokenService
   end
 
   def refresh(refresh_token)
-    @cognito.initiate_refresh_token_auth(refresh_token).authentication_result
+    @cognito.refresh_tokens(refresh_token).authentication_result
   end
 
   def exchange_challenge(session:, username:, answer:)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -72,9 +72,19 @@ RSpec.describe "Sessions", type: :request do
       end
 
       it "refreshes the session and redirects to the consumer's success URL when existing session is expired" do
+        rotated = Struct.new(:id_token, :refresh_token).new("new_id_token", "new_refresh_token")
         allow(CognitoTokenVerifier).to receive(:call).and_return(:expired)
+        allow(cognito).to receive(:get_tokens_from_refresh_token).and_return(Struct.new(:authentication_result).new(rotated))
         get new_session_path, params: { consumer_id: consumer.id }
         expect(response).to redirect_to(success_url)
+      end
+
+      it "rotates refresh token cookie when existing session is expired" do
+        rotated = Struct.new(:id_token, :refresh_token).new("new_id_token", "new_refresh_token")
+        allow(CognitoTokenVerifier).to receive(:call).and_return(:expired)
+        allow(cognito).to receive(:get_tokens_from_refresh_token).and_return(Struct.new(:authentication_result).new(rotated))
+        get new_session_path, params: { consumer_id: consumer.id }
+        expect(cookies[:refresh_token]).to eq("new_refresh_token")
       end
 
       it "returns a successful response when there is no valid or expired session" do

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,27 +4,27 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_identity-job"></a> [identity-job](#module\_identity-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.remove_unverified_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.remove_unverified_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -54,7 +54,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |


### PR DESCRIPTION
### Jira link

[OTTIMP-542](https://transformuk.atlassian.net/browse/OTTIMP-542)

### What?

When a user's authentication is renewed using a refresh token it should also update the refresh token if possible.
`admin_initiate_auth` method has been replaced with `get_tokens_from_refresh_token` which also returns a new refresh token

### Why?

If enabled in Cognito, this will restart the window for when a refresh token can be used. Without this the refresh token will eventually expire.

