### PR TITLE
BAU: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,20 +22,19 @@ repos:
         files: '.env.development|.env.test'
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.93.7
+    rev: v3.95.3
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0
     hooks:
-      - id: markdownlint-docker
+      - id: markdownlint-fix
         args:
           - "--ignore"
           - terraform
           - "--ignore"
           - .github
-          - "--fix"
 
   - repo: https://github.com/mattlqx/pre-commit-ruby
     rev: v1.3.6
@@ -44,6 +43,6 @@ repos:
         args: ["--autocorrect"]
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Run `pre-commit autoupdate` for stale hook refs where available.
- [x] Switch markdown linting from the Docker image hook to the Node `markdownlint-fix` hook.

### Why?

The `markdownlint-docker` hook pulls `ghcr.io/igorshubovych/markdownlint-cli:v0.48.0` in CI. Using the non-Docker hook avoids the GHCR image pull path while preserving markdown auto-fix behaviour.

### Validation

- `pre-commit validate-config`
- `pre-commit run markdownlint-fix --all-files`
- `git diff --check`


### Risk

**Risk level:** 🟢

**Reason for rating:**
Pre-commit hook configuration only. There is no application runtime or infrastructure behaviour change; the main risk is CI surfacing markdown or hook-version differences earlier than before.
