### PR TITLE
HMRC-2229: Add Dependabot package age cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - "needs-deployment"
 
@@ -17,3 +21,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Jira link

[HMRC-2229](https://transformuk.atlassian.net/browse/HMRC-2229)

### What?

- [x] Add a 7 day Dependabot cooldown to configured update blocks in this repo
- [x] Keep the existing update schedule and labels unchanged

### Why?

Dependabot now supports a `cooldown` option for version updates: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

Using `default-days: 7` gives newly published packages a short settling period before Dependabot proposes them. GitHub documents that this applies to version updates only, so security updates are not delayed.

### Risk

**Risk level:** Low

**Reason for rating:**
No runtime behaviour change. This only changes when Dependabot opens routine version update pull requests.
