### PR TITLE
Add cloudwatch alarm for when cognito clients crosses 800

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = ">= 2.0.0, ~> 2.0"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
@@ -26,21 +47,21 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version = "3.7.2"
+  version = "3.9.0"
   hashes = [
-    "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
-    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
-    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
-    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
-    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
-    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
-    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
-    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
-    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
-    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
-    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
-    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
   ]
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,12 +6,14 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
@@ -25,29 +27,41 @@
 
 | Name | Type |
 | ---- | ---- |
+| [aws_cloudwatch_event_rule.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.remove_unverified_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.remove_unverified_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_policy.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.eventbridge_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.eventbridge_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.cognito_app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.cognito_app_client_count_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [archive_file.cognito_app_client_count_lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cognito_user_pool) | data source |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
 | [aws_ecs_task_definition.identity_job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_task_definition) | data source |
+| [aws_iam_policy_document.cognito_app_client_count_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eventbridge_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_sns_topic.cognito_app_client_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
@@ -58,6 +72,7 @@
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_enable_cognito_app_client_count_monitor"></a> [enable\_cognito\_app\_client\_count\_monitor](#input\_enable\_cognito\_app\_client\_count\_monitor) | When true, deploy Lambda + alarm for Cognito user pool app client count (threshold 800). | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/cognito_app_client_count_monitor.tf
+++ b/terraform/cognito_app_client_count_monitor.tf
@@ -1,0 +1,165 @@
+# Hourly metric + alarm when Cognito app clients (e.g. dev-hub API keys) reach the service quota danger zone.
+
+locals {
+  cognito_app_client_count_monitor_enabled = var.enable_cognito_app_client_count_monitor
+  cognito_app_client_metric_namespace      = "TradeTariff/Identity"
+  cognito_app_client_metric_name           = "AppClientCount"
+  cognito_app_client_alarm_threshold       = 800
+}
+
+data "aws_sns_topic" "cognito_app_client_alarm" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+  name  = "slack-topic"
+}
+
+data "archive_file" "cognito_app_client_count_lambda_zip" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  type        = "zip"
+  source_file = "${path.module}/lambda/cognito_app_client_count/app_client_count.py"
+  output_path = "${path.module}/lambda/cognito_app_client_count/tmp/app_client_count.zip"
+}
+
+resource "aws_iam_role" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  name = "trade-tariff-identity-app-client-count-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+data "aws_iam_policy_document" "cognito_app_client_count_lambda" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  statement {
+    sid = "Logging"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${local.account_id}:*"]
+  }
+
+  statement {
+    sid       = "ListUserPoolClients"
+    actions   = ["cognito-idp:ListUserPoolClients"]
+    resources = [data.aws_cognito_user_pool.this.arn]
+  }
+
+  statement {
+    sid    = "PutMetricData"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = [local.cognito_app_client_metric_namespace]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  name   = "trade-tariff-identity-app-client-count-${var.environment}"
+  role   = aws_iam_role.cognito_app_client_count[0].id
+  policy = data.aws_iam_policy_document.cognito_app_client_count_lambda[0].json
+}
+
+resource "aws_cloudwatch_log_group" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  name              = "/aws/lambda/trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  retention_in_days = 14
+}
+
+resource "aws_lambda_function" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  function_name = "trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  role          = aws_iam_role.cognito_app_client_count[0].arn
+  handler       = "app_client_count.lambda_handler"
+  runtime       = "python3.11"
+  timeout       = 60
+
+  filename         = data.archive_file.cognito_app_client_count_lambda_zip[0].output_path
+  source_code_hash = data.archive_file.cognito_app_client_count_lambda_zip[0].output_base64sha256
+
+  environment {
+    variables = {
+      USER_POOL_ID     = data.aws_cognito_user_pool.this.id
+      ENVIRONMENT      = var.environment
+      METRIC_NAMESPACE = local.cognito_app_client_metric_namespace
+      METRIC_NAME      = local.cognito_app_client_metric_name
+    }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group  = aws_cloudwatch_log_group.cognito_app_client_count[0].name
+  }
+
+  depends_on = [aws_cloudwatch_log_group.cognito_app_client_count]
+}
+
+resource "aws_cloudwatch_event_rule" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  name                = "trade-tariff-identity-app-client-count-${var.environment}"
+  description         = "Publish Cognito identity pool app client count custom metric"
+  schedule_expression = "rate(1 hour)"
+}
+
+resource "aws_cloudwatch_event_target" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  rule      = aws_cloudwatch_event_rule.cognito_app_client_count[0].name
+  target_id = "trade-tariff-identity-app-client-count-${var.environment}"
+  arn       = aws_lambda_function.cognito_app_client_count[0].arn
+}
+
+resource "aws_lambda_permission" "cognito_app_client_count_events" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cognito_app_client_count[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.cognito_app_client_count[0].arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "cognito_app_client_count" {
+  count = local.cognito_app_client_count_monitor_enabled ? 1 : 0
+
+  alarm_name          = "trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  alarm_description   = "Identity Cognito user pool app clients >= ${local.cognito_app_client_alarm_threshold}. Mitigate via Service Quota increase and/or cleanup of stale credentials clients."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = local.cognito_app_client_metric_name
+  namespace           = local.cognito_app_client_metric_namespace
+  period              = 3600
+  statistic           = "Maximum"
+  threshold           = local.cognito_app_client_alarm_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    UserPoolId  = data.aws_cognito_user_pool.this.id
+    Environment = var.environment
+  }
+
+  alarm_actions = [data.aws_sns_topic.cognito_app_client_alarm[0].arn]
+  ok_actions    = [data.aws_sns_topic.cognito_app_client_alarm[0].arn]
+}

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -7,3 +7,5 @@ min_capacity  = 1
 max_capacity  = 3
 
 enable_alarms = false
+
+enable_cognito_app_client_count_monitor = true

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_vpc" "vpc" {
   tags = { Name = "trade-tariff-${var.environment}-vpc" }
 }

--- a/terraform/lambda/cognito_app_client_count/app_client_count.py
+++ b/terraform/lambda/cognito_app_client_count/app_client_count.py
@@ -1,0 +1,37 @@
+"""Publish Cognito user pool app client count as a custom CloudWatch metric."""
+
+import os
+
+import boto3
+
+METRIC_NAMESPACE = os.environ["METRIC_NAMESPACE"]
+METRIC_NAME = os.environ.get("METRIC_NAME", "AppClientCount")
+USER_POOL_ID = os.environ["USER_POOL_ID"]
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "unknown")
+
+
+def lambda_handler(event, context):
+    cognito = boto3.client("cognito-idp")
+    paginator = cognito.get_paginator("list_user_pool_clients")
+
+    total = 0
+    for page in paginator.paginate(UserPoolId=USER_POOL_ID, PaginationConfig={"PageSize": 60}):
+        total += len(page["UserPoolClients"])
+
+    cloudwatch = boto3.client("cloudwatch")
+    cloudwatch.put_metric_data(
+        Namespace=METRIC_NAMESPACE,
+        MetricData=[
+            {
+                "MetricName": METRIC_NAME,
+                "Dimensions": [
+                    {"Name": "UserPoolId", "Value": USER_POOL_ID},
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                ],
+                "Value": float(total),
+                "Unit": "Count",
+            }
+        ],
+    )
+
+    return {"statusCode": 200, "client_count": total}

--- a/terraform/lambda/cognito_app_client_count/tmp/.gitignore
+++ b/terraform/lambda/cognito_app_client_count/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,3 +55,9 @@ variable "scale_out_cooldown" {
   type        = number
   default     = 60
 }
+
+variable "enable_cognito_app_client_count_monitor" {
+  description = "When true, deploy Lambda + alarm for Cognito user pool app client count (threshold 800)."
+  type        = bool
+  default     = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">=1.12"
 
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5"


### PR DESCRIPTION
## What:
This change adds Terraform for a scheduled Lambda that counts Cognito user pool app clients (the clients created when dev-hub requests a Trade Tariff API key via identity), publishes a custom CloudWatch metric, and raises an alarm when the total reaches 800 (near typical service quota limits).

## Why:
Ownership of this alarm sits with the identity service—the app and API that create those clients—rather than the shared platform AWS Terraform repo. Staging and production use the existing slack-topic SNS topic for notifications; the monitor is disabled in development by default to avoid depending on that topic and because the limit is not relevant there.

## Ticket:
[OTTIMP-536](https://transformuk.atlassian.net/browse/OTTIMP-536)

## Risk:

**Risk level:** 🟢 /


