### PR TITLE
HMRC-2248: Update ECS Alarms routing

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_identity-job"></a> [identity-job](#module\_identity-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.2 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
 
 ## Resources
 
@@ -48,6 +48,8 @@
 | [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_sns_topic.slack_observability_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+| [aws_sns_topic.slack_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
@@ -58,6 +60,7 @@
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. Defaults to `true`. | `bool` | `true` | no |
+| <a name="input_enable_observability_alerts"></a> [enable\_observability\_alerts](#input\_enable\_observability\_alerts) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -8,3 +8,5 @@ max_capacity  = 5
 # Temporarily pinned autoscaling cooldown values in Production to preserve existing behaviour while testing changes in staging
 scale_in_cooldown  = 0
 scale_out_cooldown = 0
+
+enable_observability_alerts = true

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -50,3 +50,12 @@ data "aws_cognito_user_pool" "this" {
 data "aws_ecs_cluster" "this" {
   cluster_name = "trade-tariff-cluster-${var.environment}"
 }
+
+data "aws_sns_topic" "slack_topic" {
+  name = "slack-topic"
+}
+
+data "aws_sns_topic" "slack_observability_topic" {
+  count = var.enable_observability_alerts ? 1 : 0
+  name  = "slack-observability-topic"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.2"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.1.0"
 
   region = var.region
 
@@ -46,5 +46,8 @@ module "service" {
   }
 
   enable_alarms       = var.enable_alarms
-  cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during deployments, will be adjusted based on observed metrics after testing is complete.
+  cpu_alarm_threshold = 35
+
+  sns_topic_arns               = [data.aws_sns_topic.slack_topic.arn]
+  observability_sns_topic_arns = var.enable_observability_alerts ? [data.aws_sns_topic.slack_observability_topic[0].arn] : null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,6 +44,11 @@ variable "enable_alarms" {
   default     = true
 }
 
+variable "enable_observability_alerts" {
+  type    = bool
+  default = false
+}
+
 variable "scale_in_cooldown" {
   description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
   type        = number


### PR DESCRIPTION
## What:

- Bumps ECS service module ref to pick up new `observability_sns_topic_arns` variable
- Adds `data.aws_sns_topic.slack_topic` and `data.aws_sns_topic.slack_observability_topic` lookup
- Passes `observability_sns_topic_arns` to ECS service module callers. This routes `ecs_capacity_loss` and `ecs_high_cpu` to `#production-observability` and keeps service_count in `#production-alerts.`

## Why:
- Enables CW alarm action to send Slack notifications
- Reduces noise in `#production-alerts` by moving degraded-but-not-down signals to the observability channel. On-call engineers see only alarms requiring immediate action in the main channel.

## Ticket:
[HMRC-2248](https://transformuk.atlassian.net/browse/HMRC-2248)

## Risk:

**Risk level:** 
🟢
**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->