### PR TITLE
Add SimpleCov coverage reporting to the identity test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 group :test do
   gem "factory_bot_rails"
   gem "rspec-rails"
+  gem "simplecov"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -331,6 +332,12 @@ GEM
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.1)
@@ -388,6 +395,7 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rspec-rails
   rubocop-govuk
+  simplecov
   web-console
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,12 @@
 # This file is copied to spec/ when you run "rails generate rspec:install"
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+
+SimpleCov.start "rails"
+SimpleCov.formatters = SimpleCov::Formatter::HTMLFormatter
+
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
## What:
Added SimpleCov coverage reporting to the `identity` test suite.

## Why:
Gives `identity` the local test coverage visibility.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Only affects the test environment.
