### PR TITLE
Use govuk components helpers in passwordless views

### DIFF
--- a/app/views/passwordless/show.html.erb
+++ b/app/views/passwordless/show.html.erb
@@ -6,24 +6,16 @@
 <p class="govuk-body">You must follow the link in the email to verify your email address.</p>
 <div class="govuk-inset-text">The link will stop working after 15 minutes.</div>
 
-<details class="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Not received an email?
-    </span>
-  </summary>
+<%= govuk_details(summary_text: "Not received an email?") do %>
+  <p class="govuk-body">
+    Emails sometimes take a few minutes to arrive.
+  </p>
 
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Emails sometimes take a few minutes to arrive.
-    </p>
+  <p class="govuk-body">
+    If you do not receive an email soon, check your spam or junk folder.
+  </p>
 
-    <p class="govuk-body">
-      If you do not receive an email soon, check your spam or junk folder.
-    </p>
-
-    <p class="govuk-body">
-      If this does not work, <a class="govuk-link" href="mailto:tariffmanagement@hmrc.gov.uk">contact us</a> for help.
-    </p>
-  </div>
-</details>
+  <p class="govuk-body">
+    If this does not work, <%= govuk_link_to "contact us", "mailto:tariffmanagement@hmrc.gov.uk" %> for help.
+  </p>
+<% end %>

--- a/app/views/sessions/_passwordless.html.erb
+++ b/app/views/sessions/_passwordless.html.erb
@@ -16,8 +16,8 @@
   </p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/privacy" target="_blank">privacy notice (opens in new tab)</a>, which explains how we use your personal information</li>
-    <li><a class="govuk-link" href="https://www.trade-tariff.service.gov.uk/terms" target="_blank">terms and conditions (opens in new tab)</a></li>
+    <li><%= govuk_link_to "privacy notice", "https://www.trade-tariff.service.gov.uk/privacy", new_tab: true %>, which explains how we use your personal information</li>
+    <li><%= govuk_link_to "terms and conditions", "https://www.trade-tariff.service.gov.uk/terms", new_tab: true %></li>
   </ul>
 
   <%= f.govuk_submit %>

--- a/app/views/sessions/_passwordless.html.erb
+++ b/app/views/sessions/_passwordless.html.erb
@@ -15,10 +15,10 @@
     By continuing, you confirm that you agree to our:
   </p>
 
-  <ul class="govuk-list govuk-list--bullet">
+  <%= govuk_list(type: :bullet) do %>
     <li><%= govuk_link_to "privacy notice", "https://www.trade-tariff.service.gov.uk/privacy", new_tab: true %>, which explains how we use your personal information</li>
     <li><%= govuk_link_to "terms and conditions", "https://www.trade-tariff.service.gov.uk/terms", new_tab: true %></li>
-  </ul>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>


### PR DESCRIPTION
## What
Convert passwordless views to use govuk-components helpers for details, links, and lists.

## Why
Align the templates with the shared helper APIs and remove raw GOV.UK HTML markup.

## Ticket
N/A

## Risk

**Risk level:** 🟢

**Reason for rating:**
Template-only refactor with no logic changes. Existing request specs continue to pass.
