### PR TITLE
HMRC-2247: Investigate auto-merging low-risk PRs with a successful Copilot review

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,26 @@
+name: Auto-merge low-risk PRs
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+  workflow_run:
+    workflows:
+      - 'ci'
+    types:
+      - completed
+
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
+    with:
+      label: low-risk
+      merge-method: merge
+    secrets:
+      github-token: ${{ secrets.PULL_REQUEST_PAT }}


### PR DESCRIPTION
## What:
Add auto merge small pr with copilot review workflow

## Why:
Low-risk PRs (those without the high-risk or medium-risk label, passing all CI checks) often sit waiting for a human reviewer despite being straightforward changes. Enabling auto-merge for these PRs — gated on a successful Copilot review — could significantly reduce cycle time and free up reviewer bandwidth for more complex work.

## Ticket:
[HMRC-2247](https://transformuk.atlassian.net/browse/HMRC-2247)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
It is a github workflow changes that tested in backend already