### PR TITLE
HMRC-2401 Carry MyOTT return URL through Identity

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,16 @@ class ApplicationController < ActionController::Base
     @current_consumer ||= Consumer.load(consumer_id)
   end
 
+  def success_url
+    return current_consumer.success_url if session[:return_to].blank?
+
+    uri = URI.parse(current_consumer.success_url)
+    query = Rack::Utils.parse_nested_query(uri.query)
+    query["return_to"] = session.delete(:return_to)
+    uri.query = query.to_query
+    uri.to_s
+  end
+
   def clear_cookies
     return if current_consumer.nil?
 
@@ -40,6 +50,16 @@ private
 
   def consumer_id
     params[:consumer_id] || session[:consumer_id]
+  end
+
+  def safe_return_to
+    return_to = params[:return_to].to_s
+    return if return_to.blank?
+    # Identity only preserves relative consumer paths. The consuming app owns
+    # route-level allowlisting before it follows the returned path.
+    return unless return_to.start_with?("/") && !return_to.start_with?("//")
+
+    return_to
   end
 
   def id_token_cookie_name

--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -49,7 +49,7 @@ class PasswordlessController < ApplicationController
 
     set_cookies(tokens)
 
-    redirect_to current_consumer.success_url, allow_other_host: true
+    redirect_to success_url, allow_other_host: true
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
     redirect_to current_consumer.failure_url, allow_other_host: true
   rescue StandardError => e

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,7 @@ class SessionsController < ApplicationController
 
   def index
     session[:consumer_id] = current_consumer.id
+    session[:return_to] = safe_return_to if safe_return_to.present?
     redirect_to login_path
   end
 
@@ -25,10 +26,10 @@ private
   def check_session
     case CognitoTokenVerifier.call(cookies[id_token_cookie_name], current_consumer)
     when :valid
-      redirect_to current_consumer.success_url, allow_other_host: true and return
+      redirect_to success_url, allow_other_host: true and return
     when :expired
       if refresh_session_with_token
-        redirect_to current_consumer.success_url, allow_other_host: true and return
+        redirect_to success_url, allow_other_host: true and return
       end
     when :invalid
       clear_cookies

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -126,6 +126,15 @@ RSpec.describe "Passwordless", type: :request do
         get callback_passwordless_path, params: { email:, token: "token" }
         expect(response).to redirect_to(consumer.success_url)
       end
+
+      it "redirects to the consumer's success URL with the stored return URL" do
+        get root_path, params: { consumer_id: consumer.id, return_to: "/subscriptions/mycommodities?as_of=2025-06-20" }
+        post passwordless_path, params: { passwordless_form: { email: } }
+
+        get callback_passwordless_path, params: { email:, token: "token" }
+
+        expect(response).to redirect_to("#{consumer.success_url}?return_to=%2Fsubscriptions%2Fmycommodities%3Fas_of%3D2025-06-20")
+      end
     end
 
     context "when link id invalid" do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe "Sessions", type: :request do
         expect(session[:consumer_id]).to eq(consumer.id)
       end
 
+      it "stores a relative return URL in the session" do
+        get sessions_path, params: { consumer_id: consumer.id, return_to: "/subscriptions/mycommodities?as_of=2025-06-20" }
+        expect(session[:return_to]).to eq("/subscriptions/mycommodities?as_of=2025-06-20")
+      end
+
+      it "does not store an absolute return URL in the session" do
+        get sessions_path, params: { consumer_id: consumer.id, return_to: "https://example.com/phishing" }
+        expect(session[:return_to]).to be_nil
+      end
+
+      it "does not store a protocol-relative return URL in the session" do
+        get sessions_path, params: { consumer_id: consumer.id, return_to: "//example.com/phishing" }
+        expect(session[:return_to]).to be_nil
+      end
+
       it "prioritizes params consumer_id over session consumer_id", :aggregate_failures do
         allow(Consumer).to receive(:load).with(stale_consumer.id).and_return(stale_consumer)
 


### PR DESCRIPTION
## What:
Carry a safe relative `return_to` value through the Identity MyOTT login flow and append it to the configured consumer success URL.

This lets the consumer receive the original MyOTT destination after login, rather than always completing the Identity journey at the generic subscriptions landing URL.

## Why:
CCWL email links can point at a dated MyOTT page, for example `/subscriptions/mycommodities?as_of=YYYY-MM-DD`. The frontend can recover that destination from its own session in some flows, but that makes the journey indirect: successful login first returns to `/subscriptions`, then frontend has to look up and replay the original destination.

By preserving an explicit relative `return_to`, Identity can hand the intended destination back to the consumer as part of the normal success redirect. The user is then sent straight to the URL they clicked after authentication, while frontend remains responsible for validating and following that returned path.

Identity does not take ownership of frontend route validation here. It only preserves a relative path and appends it to the consumer success URL for the consumer to handle.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2401

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Low risk bug fix. The change preserves the existing consumer success URL contract and only adds a relative `return_to` parameter for the consumer to validate; it does not change Cognito configuration, token lifetimes, cookie attributes, or authorisation rules.