### PR TITLE
Background the Cognito add-to-group call in passwordless sign-in

### DIFF
--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -11,7 +11,7 @@ class PasswordlessController < ApplicationController
     email = @passwordless.email
 
     find_or_create_user(email)
-    add_user_to_consumer_group(email)
+    AddUserToConsumerGroupJob.perform_later(email, current_consumer.id)
 
     resp = initiate_passwordless_auth(email)
 
@@ -63,10 +63,6 @@ private
     cognito.find_user(email)
   rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
     cognito.create_user(email, email:)
-  end
-
-  def add_user_to_consumer_group(email)
-    cognito.add_to_group(email, group_name: current_consumer.id)
   end
 
   def initiate_passwordless_auth(email)

--- a/app/jobs/add_user_to_consumer_group_job.rb
+++ b/app/jobs/add_user_to_consumer_group_job.rb
@@ -1,0 +1,9 @@
+class AddUserToConsumerGroupJob < ApplicationJob
+  queue_as :default
+
+  def perform(email, group_name)
+    CognitoServiceAdapter.new.add_to_group(email, group_name:)
+  rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+    Rails.logger.error(e)
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Track enqueued jobs instead of running them, so specs can assert on them.
+  config.active_job.queue_adapter = :test
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/spec/jobs/add_user_to_consumer_group_job_spec.rb
+++ b/spec/jobs/add_user_to_consumer_group_job_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe AddUserToConsumerGroupJob, type: :job do
+  let(:cognito) { instance_double(CognitoServiceAdapter) }
+  let(:email) { "test@email.com" }
+  let(:group_name) { "consumer-id" }
+
+  before do
+    allow(CognitoServiceAdapter).to receive(:new).and_return(cognito)
+    allow(cognito).to receive(:add_to_group)
+  end
+
+  it "adds the user to the consumer's group" do
+    described_class.perform_now(email, group_name)
+
+    expect(cognito).to have_received(:add_to_group).with(email, group_name:)
+  end
+
+  it "logs and swallows Cognito errors instead of raising" do
+    allow(cognito).to receive(:add_to_group).and_raise(
+      Aws::CognitoIdentityProvider::Errors::ServiceError.new(nil, "boom"),
+    )
+
+    expect { described_class.perform_now(email, group_name) }.not_to raise_error
+  end
+end

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -28,11 +28,10 @@ RSpec.describe "Passwordless", type: :request do
       expect(cognito).to have_received(:admin_create_user)
     end
 
-    it "adds the user to the consumer's group" do
-      post passwordless_path, params: { passwordless_form: { email: } }
-      expect(cognito).to have_received(:admin_add_user_to_group).with(
-        hash_including(group_name: consumer.id),
-      )
+    it "enqueues a job to add the user to the consumer's group" do
+      expect {
+        post passwordless_path, params: { passwordless_form: { email: } }
+      }.to have_enqueued_job(AddUserToConsumerGroupJob).with(email, consumer.id)
     end
 
     it "initiates auth with auth params" do


### PR DESCRIPTION
## What:
Moves the Cognito `add_to_group` call in `PasswordlessController#create` out of the synchronous request path and into a background job (`AddUserToConsumerGroupJob`, ActiveJob default `:async` adapter).

## Why:
The New Relic `identity - Latency` SLI alert was firing because `passwordless#create` makes 3-4 sequential, blocking Cognito API calls (`find_user`/`create_user` → `add_to_group` → `initiate_custom_auth`), each a network round-trip, adding up to ~1.7-2.2s. `add_to_group` is the only one of these that doesn't need to complete before the response - nothing in the login/callback path (Cognito Lambda triggers, the `callback` action, `current_consumer`) reads group membership; it's only consulted later by downstream consumer-authorization checks (`User.find(username, group)`). `find_or_create_user` and `initiate_custom_auth` stay synchronous: the latter's session token is needed immediately to continue the auth flow, and Cognito requires the user to exist before `initiate_custom_auth` can run.

No new infrastructure: uses ActiveJob's in-process `:async` adapter rather than Sidekiq/Redis, since the operation is idempotent and non-critical to login - a lost job on process restart just delays the group add slightly rather than breaking sign-in.

## Ticket:
N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:** This changes the passwordless sign-in flow's behaviour, which the risk guide calls out as Amber by default. The specific risk: for a **brand-new user's first login**, group membership is no longer guaranteed to exist by the time tokens are issued - there's now a small race window where `add_to_group` (background job) could still be in flight when the user reaches a downstream service that checks group membership (`User.find(username, group)`). For existing users, this is a no-op risk since they're already in the group. Recommend socialising before merge and watching for any downstream "user not authorized" errors on first-time sign-ups after deploy; easy rollback (revert to synchronous call) if seen.

───────────────────────────────────────────────────

## Test plan
- [x] `bundle exec rspec` - 124 examples, 0 failures
- [x] `bundle exec rubocop` - no offenses on changed files
- [ ] Confirm in New Relic that `passwordless#create`'s external duration drops after deploy
- [ ] Watch for any authorization failures on new-user first sign-in immediately after deploy