### PR TITLE
HMRC-2408 Add Debride pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
           terraform_docs_version: 0.22.0
       - run: cd terraform/ && terraform init -backend=false -reconfigure
       - run: pip install pre-commit
-      - run: pre-commit run --all-files
+      - run: pre-commit run --all-files --hook-stage pre-commit
+      - run: pre-commit run --all-files --hook-stage pre-push
       - run: bundle exec brakeman
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 ---
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+default_stages:
+  - pre-commit
+
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
@@ -52,3 +58,8 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint-docker
+
+  - repo: https://github.com/trade-tariff/trade-tariff-tools
+    rev: main
+    hooks:
+      - id: debride

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
 end
 
 group :test do
+  gem "debride", "~> 1.15", require: false
   gem "factory_bot_rails"
   gem "rspec-rails"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
+    debride (1.15.2)
+      path_expander (~> 2.0)
+      prism (~> 1.7)
+      sexp_processor (~> 4.17)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -214,6 +218,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    path_expander (2.0.1)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -332,6 +337,7 @@ GEM
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sexp_processor (4.17.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -379,6 +385,7 @@ DEPENDENCIES
   aws-sdk-cognitoidentityprovider
   bootsnap
   brakeman
+  debride (~> 1.15)
   debug
   dotenv-rails
   factory_bot_rails

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -1,0 +1,26 @@
+# Debride cannot see framework convention calls reliably.
+# This normalized baseline is compared by trade-tariff-tools/debride.
+
+Api::ClientCredentialsController#cognito_service_error
+Api::ClientCredentialsController#create
+Api::ClientCredentialsController#invalid_parameter
+Api::UsersController#show
+ApplicationHelper#page_title
+Consumer#cookie_domain=
+Consumer#failure_url=
+Consumer#id=
+Consumer#methods=
+Consumer#success_url=
+ErrorsController#bad_request
+ErrorsController#internal_server_error
+ErrorsController#not_found
+HealthcheckController#check
+HealthcheckController#checkz
+PasswordlessController#callback
+PasswordlessController#create
+PasswordlessController#show
+PasswordlessForm#email=
+SessionsController#index
+SessionsController#new
+User#email=
+User#username=

--- a/flake.lock
+++ b/flake.lock
@@ -138,7 +138,8 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-ruby": "nixpkgs-ruby",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "trade-tariff-tools": "trade-tariff-tools"
       }
     },
     "systems": {
@@ -153,6 +154,23 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "trade-tariff-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782213097,
+        "narHash": "sha256-uQyF1hojMxmw1yY1ReMEebbKyAnjKSdG/Zkx5j3MDSs=",
+        "owner": "trade-tariff",
+        "repo": "trade-tariff-tools",
+        "rev": "1cf7af52c35d7a3425c424731320423f4fea1486",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trade-tariff",
+        "ref": "main",
+        "repo": "trade-tariff-tools",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+    trade-tariff-tools = {
+      url = "github:trade-tariff/trade-tariff-tools/main";
+      flake = false;
+    };
   };
 
   outputs =
@@ -19,6 +23,7 @@
       flake-utils,
       pre-commit-hooks,
       nixpkgs-ruby,
+      trade-tariff-tools,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -199,6 +204,14 @@
             trufflehog = {
               enable = true;
               stages = [ "pre-commit" ];
+            };
+            debride = {
+              enable = true;
+              name = "debride";
+              description = "Run Debride before pushing";
+              entry = "${trade-tariff-tools}/.github/actions/debride/debride-check";
+              pass_filenames = false;
+              stages = [ "pre-push" ];
             };
 
             rubocop = {


### PR DESCRIPTION
## What:
Adds Debride as a Bundler-backed dead-code check and wires it into the pre-push hook stage for Nix and non-Nix pre-commit setups. Where this repo already runs pre-commit in CI, CI now explicitly runs both pre-commit and pre-push hook stages.

The hook implementation is consumed from the shared `trade-tariff-tools` Debride action/pre-commit hook introduced in trade-tariff/trade-tariff-tools#154.

## Why:
This keeps newly introduced unused Ruby methods visible before review and shares the implementation across Trade Tariff Ruby repos instead of copying hook logic.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2408

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Developer-tooling and CI validation only. This does not change runtime application behavior, deployed infrastructure, data processing, API behavior, or trader-facing content.

## Verification:
- `pre-commit validate-config .pre-commit-config.yaml`
- `pre-commit run -c .pre-commit-config.yaml --all-files --hook-stage pre-push debride`
- `nix develop -c pre-commit run --all-files --hook-stage pre-push debride`
- Commit hooks passed for this branch
- Push hook ran Debride successfully for this branch
