### PR TITLE
Memoize EncryptionService key derivation

### DIFF
--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,15 +1,18 @@
 class EncryptionService
   def self.encrypt_string(string)
-    new.crypt.encrypt_and_sign(string)
+    encryptor.encrypt_and_sign(string)
   end
 
   def self.decrypt_string(encrypted_string)
-    new.crypt.decrypt_and_verify(encrypted_string)
+    encryptor.decrypt_and_verify(encrypted_string)
   end
 
-  def crypt
-    secret = TradeTariffIdentity.encryption_secret
-    key = ActiveSupport::KeyGenerator.new(secret).generate_key("identity_token_encryption_v1", 32)
-    ActiveSupport::MessageEncryptor.new(key)
+  def self.encryptor
+    @encryptor ||= begin
+      key = ActiveSupport::KeyGenerator
+              .new(TradeTariffIdentity.encryption_secret)
+              .generate_key("identity_token_encryption_v1", 32)
+      ActiveSupport::MessageEncryptor.new(key)
+    end
   end
 end

--- a/spec/services/encryption_service_spec.rb
+++ b/spec/services/encryption_service_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe EncryptionService, type: :service do
 
   describe ".encryptor" do
     it "returns the same instance on repeated calls" do
-      expect(described_class.encryptor).to be(described_class.encryptor)
+      first_call = described_class.encryptor
+      expect(described_class.encryptor).to be(first_call)
     end
   end
 

--- a/spec/services/encryption_service_spec.rb
+++ b/spec/services/encryption_service_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe EncryptionService, type: :service do
     end
   end
 
+  describe ".encryptor" do
+    it "returns the same instance on repeated calls" do
+      expect(described_class.encryptor).to be(described_class.encryptor)
+    end
+  end
+
   describe ".decrypt_string" do
     it "decrypts an encrypted string back to the original" do
       decrypted_string = described_class.decrypt_string(encrypted_string)


### PR DESCRIPTION
## What:
Memoize `EncryptionService` key derivation at the class level. The `crypt` instance method called `KeyGenerator#generate_key` on every encrypt/decrypt operation. Replaced with a class-level `encryptor` method memoized via `@encryptor ||=`.

## Why:
PBKDF key stretching is intentionally expensive. The secret and salt are static for the lifetime of the process, so there is no reason to re-derive the key on every call. This runs the expensive step once per process instead.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2461

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Refactor with no behaviour change — public API (`encrypt_string` / `decrypt_string`) is identical, all existing specs pass, and a new spec verifies the encryptor is memoized.