### PR TITLE
fix: replace broad rescue StandardError with specific AWS error handling in auth controllers

### DIFF
--- a/app/controllers/passwordless_controller.rb
+++ b/app/controllers/passwordless_controller.rb
@@ -19,8 +19,8 @@ class PasswordlessController < ApplicationController
     session[:login] = resp.session
 
     redirect_to passwordless_path
-  rescue StandardError => e
-    Rails.logger.error(e)
+  rescue Aws::Errors::ServiceError => e
+    Rails.logger.error(e.full_message)
     redirect_to login_path, alert: "Something went wrong. Please try again."
   end
 
@@ -52,8 +52,8 @@ class PasswordlessController < ApplicationController
     redirect_to success_url, allow_other_host: true
   rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
     redirect_to current_consumer.failure_url, allow_other_host: true
-  rescue StandardError => e
-    Rails.logger.error(e)
+  rescue Aws::Errors::ServiceError => e
+    Rails.logger.error(e.full_message)
     redirect_to current_consumer.failure_url, allow_other_host: true
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,8 +46,8 @@ private
     rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
       clear_cookies
       false
-    rescue StandardError => e
-      Rails.logger.error("Token refresh failed: #{e.message}")
+    rescue Aws::Errors::ServiceError => e
+      Rails.logger.error("Token refresh failed: #{e.full_message}")
       false
     end
   end

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -96,11 +96,12 @@ RSpec.describe "Passwordless", type: :request do
       let(:cognito_auth_object) { Data.define(:authentication_result).new(authentication_result) }
 
       before do
-        allow(cognito).to receive(:admin_initiate_auth).and_return(Data.define(:session).new("session"))
+        allow(cognito).to receive_messages(
+          admin_initiate_auth: Data.define(:session).new("session"),
+          respond_to_auth_challenge: cognito_auth_object,
+          admin_update_user_attributes: nil,
+        )
         post passwordless_path, params: { passwordless_form: { email: } }
-
-        allow(cognito).to receive(:respond_to_auth_challenge).and_return(cognito_auth_object)
-        allow(cognito).to receive(:admin_update_user_attributes)
       end
 
       it "responds to auth challenge" do

--- a/spec/requests/passwordless_spec.rb
+++ b/spec/requests/passwordless_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "Passwordless", type: :request do
       expect(response).to redirect_to(passwordless_path)
     end
 
-    it "redirects to login_path on error" do
-      allow(cognito).to receive(:admin_initiate_auth).and_raise(StandardError.new("Error"))
+    it "redirects to login_path on Cognito service errors" do
+      allow(cognito).to receive(:admin_initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::TooManyRequestsException.new(nil, "Too many requests"))
       post passwordless_path, params: { passwordless_form: { email: } }
       expect(response).to redirect_to(login_path)
     end
@@ -96,7 +96,8 @@ RSpec.describe "Passwordless", type: :request do
       let(:cognito_auth_object) { Data.define(:authentication_result).new(authentication_result) }
 
       before do
-        post passwordless_path, params: { email: }
+        allow(cognito).to receive(:admin_initiate_auth).and_return(Data.define(:session).new("session"))
+        post passwordless_path, params: { passwordless_form: { email: } }
 
         allow(cognito).to receive(:respond_to_auth_challenge).and_return(cognito_auth_object)
         allow(cognito).to receive(:admin_update_user_attributes)
@@ -145,9 +146,9 @@ RSpec.describe "Passwordless", type: :request do
       end
     end
 
-    context "when an error occurs" do
+    context "when a Cognito service error occurs" do
       it "redirects to the consumer's failure URL" do
-        allow(cognito).to receive(:respond_to_auth_challenge).and_raise(StandardError.new("Error"))
+        allow(cognito).to receive(:respond_to_auth_challenge).and_raise(Aws::CognitoIdentityProvider::Errors::TooManyRequestsException.new(nil, "Too many requests"))
         get callback_passwordless_path, params: { email:, token: "token" }
         expect(response).to redirect_to(consumer.failure_url)
       end


### PR DESCRIPTION
## What:
Replace `rescue StandardError` with `rescue Aws::Errors::ServiceError` in the three auth controller error handlers, and change `Rails.logger.error(e)` to `Rails.logger.error(e.full_message)` throughout.

Also fixes a latent test bug in the callback spec where a misconfigured stub was causing a `NoMethodError` that was silently swallowed by the broad rescue.

## Why:
`PasswordlessController#create`, `PasswordlessController#callback`, and `SessionsController#refresh_session_with_token` were all catching `StandardError`, meaning real programming errors (nil dereferences, unexpected method calls) were indistinguishable from expected Cognito failures. Bugs were silently redirected away rather than surfacing in logs or error tracking.

`Aws::Errors::ServiceError` is the parent class of all AWS/Cognito service errors, so throttling, network failures, and invalid API responses are still caught and handled gracefully. Anything else (a `NoMethodError`, etc.) now bubbles to Rails' default error handler.

The logger change from `e` to `e.full_message` means backtraces are now captured, not just the error message string.

## Ticket:
https://transformud.atlassian.net/browse/HMRC-2462

## Risk:

**Risk level:**  🟢

**Reason for rating:** Changes error handling on the sign-in callback and session refresh paths. Expected Cognito errors are still caught — only unexpected programming errors will now propagate rather than being silently swallowed. Low probability of user impact.