### PR TITLE
Fix constant evaluated at class load time to avoid risk of unset env

### DIFF
--- a/app/services/cognito_token_verifier.rb
+++ b/app/services/cognito_token_verifier.rb
@@ -1,6 +1,10 @@
 class CognitoTokenVerifier
   def self.issuer
-    "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['COGNITO_USER_POOL_ID']}"
+    region = ENV.fetch("AWS_REGION")
+    user_pool_id = TradeTariffIdentity.cognito_user_pool_id
+    raise KeyError, "key not found: COGNITO_USER_POOL_ID" unless user_pool_id
+
+    "https://cognito-idp.#{region}.amazonaws.com/#{user_pool_id}"
   end
 
   def self.jwks_url

--- a/app/services/cognito_token_verifier.rb
+++ b/app/services/cognito_token_verifier.rb
@@ -1,6 +1,11 @@
 class CognitoTokenVerifier
-  ISSUER = "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['COGNITO_USER_POOL_ID']}".freeze
-  JWKS_URL = "#{ISSUER}/.well-known/jwks.json".freeze
+  def self.issuer
+    "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['COGNITO_USER_POOL_ID']}"
+  end
+
+  def self.jwks_url
+    "#{issuer}/.well-known/jwks.json"
+  end
 
   def self.call(token, consumer)
     new(token, consumer).call
@@ -46,7 +51,7 @@ private
       JWT.decode(token_to_decode, nil, true,
                  algorithms: %w[RS256],
                  jwks: { keys: jwks_keys },
-                 iss: ISSUER,
+                 iss: self.class.issuer,
                  verify_iss: true)
     end
   end
@@ -62,7 +67,7 @@ private
 
   def fetch_jwks_keys
     Rails.cache.fetch("cognito_jwks_keys", expires_in: 1.hour) do
-      response = Faraday.get(JWKS_URL)
+      response = Faraday.get(self.class.jwks_url)
       JSON.parse(response.body)["keys"] if response.success?
     end
   end

--- a/spec/services/cognito_token_verifier_spec.rb
+++ b/spec/services/cognito_token_verifier_spec.rb
@@ -1,10 +1,26 @@
 require "rails_helper"
 
 RSpec.describe CognitoTokenVerifier do
+  describe ".issuer" do
+    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars" do
+      stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "eu-west-2", "COGNITO_USER_POOL_ID" => "pool-123"))
+
+      expect(described_class.issuer).to eq("https://cognito-idp.eu-west-2.amazonaws.com/pool-123")
+    end
+  end
+
+  describe ".jwks_url" do
+    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars" do
+      stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "eu-west-2", "COGNITO_USER_POOL_ID" => "pool-123"))
+
+      expect(described_class.jwks_url).to eq("https://cognito-idp.eu-west-2.amazonaws.com/pool-123/.well-known/jwks.json")
+    end
+  end
+
   describe ".call" do
     let(:token) { "test-token" }
     let(:consumer) { build(:consumer, id: "myott") }
-    let(:jwks_url) { "https://cognito-idp.#{ENV['AWS_REGION']}.amazonaws.com/#{ENV['COGNITO_USER_POOL_ID']}/.well-known/jwks.json" }
+    let(:jwks_url) { described_class.jwks_url }
     let(:jwks_keys) { { "keys" => [{ "kty" => "RSA", "kid" => "test-kid", "use" => "sig" }] } }
     let(:decoded_token) { [{ "sub" => "1234567890", "email" => "test@example.com", "cognito:groups" => %w[myott] }] }
 
@@ -22,7 +38,7 @@ RSpec.describe CognitoTokenVerifier do
 
       it "verifies the token" do
         described_class.call(token, consumer)
-        expect(JWT).to have_received(:decode).with(token, nil, true, algorithms: %w[RS256], jwks: hash_including(:keys), iss: anything, verify_iss: true)
+        expect(JWT).to have_received(:decode).with(token, nil, true, algorithms: %w[RS256], jwks: hash_including(:keys), iss: described_class.issuer, verify_iss: true)
       end
     end
 

--- a/spec/services/cognito_token_verifier_spec.rb
+++ b/spec/services/cognito_token_verifier_spec.rb
@@ -2,18 +2,56 @@ require "rails_helper"
 
 RSpec.describe CognitoTokenVerifier do
   describe ".issuer" do
-    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars" do
-      stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "eu-west-2", "COGNITO_USER_POOL_ID" => "pool-123"))
+    before do
+      allow(ENV).to receive(:fetch).with("AWS_REGION").and_return("us-east-1", "eu-north-1")
+      allow(ENV).to receive(:[]).with("COGNITO_USER_POOL_ID").and_return("pool-111", "pool-222")
+    end
 
-      expect(described_class.issuer).to eq("https://cognito-idp.eu-west-2.amazonaws.com/pool-123")
+    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars", :aggregate_failures do
+      first_issuer = described_class.issuer
+      second_issuer = described_class.issuer
+
+      expect(first_issuer).to eq("https://cognito-idp.us-east-1.amazonaws.com/pool-111")
+      expect(second_issuer).to eq("https://cognito-idp.eu-north-1.amazonaws.com/pool-222")
+    end
+
+    it "raises an error when AWS_REGION is missing" do
+      allow(ENV).to receive(:fetch).with("AWS_REGION").and_raise(KeyError)
+
+      expect { described_class.issuer }.to raise_error(KeyError)
+    end
+
+    it "raises an error when COGNITO_USER_POOL_ID is missing" do
+      allow(ENV).to receive(:[]).with("COGNITO_USER_POOL_ID").and_return(nil)
+
+      expect { described_class.issuer }.to raise_error(KeyError)
     end
   end
 
   describe ".jwks_url" do
-    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars" do
-      stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "eu-west-2", "COGNITO_USER_POOL_ID" => "pool-123"))
+    before do
+      allow(ENV).to receive(:fetch).with("AWS_REGION").and_return("us-east-1", "us-west-1")
+      allow(ENV).to receive(:[]).with("COGNITO_USER_POOL_ID").and_return("pool-333", "pool-444")
+    end
 
-      expect(described_class.jwks_url).to eq("https://cognito-idp.eu-west-2.amazonaws.com/pool-123/.well-known/jwks.json")
+    it "reflects the current AWS_REGION and COGNITO_USER_POOL_ID env vars", :aggregate_failures do
+      first_jwks_url = described_class.jwks_url
+      second_jwks_url = described_class.jwks_url
+
+      expect(first_jwks_url).to eq("https://cognito-idp.us-east-1.amazonaws.com/pool-333/.well-known/jwks.json")
+      expect(second_jwks_url).to eq("https://cognito-idp.us-west-1.amazonaws.com/pool-444/.well-known/jwks.json")
+    end
+
+    it "raises an error when AWS_REGION is missing" do
+      allow(ENV).to receive(:fetch).with("AWS_REGION").and_raise(KeyError)
+
+      expect { described_class.jwks_url }.to raise_error(KeyError)
+    end
+
+    it "raises an error when COGNITO_USER_POOL_ID is missing" do
+      allow(ENV).to receive(:[]).with("COGNITO_USER_POOL_ID").and_return(nil)
+
+      expect { described_class.jwks_url }.to raise_error(KeyError)
     end
   end
 
@@ -25,6 +63,7 @@ RSpec.describe CognitoTokenVerifier do
     let(:decoded_token) { [{ "sub" => "1234567890", "email" => "test@example.com", "cognito:groups" => %w[myott] }] }
 
     before do
+      allow(TradeTariffIdentity).to receive(:cognito_user_pool_id).and_return("test-pool")
       allow(Faraday).to receive(:get).with(jwks_url).and_return(instance_double(Faraday::Response, success?: true, body: jwks_keys.to_json))
       allow(EncryptionService).to receive(:decrypt_string).and_return(token)
       allow(JWT).to receive(:decode).and_return(decoded_token)


### PR DESCRIPTION
## What:
Update `ISSUER` and `JWKS_URL` to class methods

## Why:

`ENV['AWS_REGION'] `and `ENV['COGNITO_USER_POOL_ID'] `are string-interpolated into frozen constants at class load time. If any of them  is unset at boot the constants `ISSUER` and `JWKS_URL`  bake in wrong values making token verification silently broken.

## Ticket:
https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2459

## Risk:

**Risk level:** 🟢 Green
**Reason for rating:**
It is a refactor with test coverage so it should not ideally break anything. 

