### PR TITLE
refactor: replace raw Cognito client in RemoveUnverifiedUsers with CognitoServiceAdapter

### DIFF
--- a/app/services/remove_unverified_users.rb
+++ b/app/services/remove_unverified_users.rb
@@ -3,12 +3,10 @@ class RemoveUnverifiedUsers
     new.call
   end
 
-  def initialize(client: TradeTariffIdentity.cognito_client,
-                 user_pool_id: TradeTariffIdentity.cognito_user_pool_id,
+  def initialize(adapter: CognitoServiceAdapter.new,
                  group_id: ENV["MYOTT_ID"],
                  cutoff_time: 1.day.ago)
-    @client = client
-    @user_pool_id = user_pool_id
+    @adapter = adapter
     @group_id = group_id
     @cutoff_time = cutoff_time
   end
@@ -17,10 +15,7 @@ class RemoveUnverifiedUsers
     pagination_token = nil
 
     loop do
-      response = client.list_users({
-        user_pool_id: user_pool_id,
-        pagination_token: pagination_token,
-      }.compact)
+      response = adapter.list_users(pagination_token: pagination_token)
 
       response.users.each do |user|
         next if verified?(user) || user.user_create_date > cutoff_time
@@ -35,7 +30,7 @@ class RemoveUnverifiedUsers
 
 private
 
-  attr_reader :client, :cutoff_time, :group_id, :user_pool_id
+  attr_reader :adapter, :cutoff_time, :group_id
 
   def verified?(user)
     user.attributes.find { |attr| attr.name == "email_verified" }&.value == "true"

--- a/spec/services/remove_unverified_users_spec.rb
+++ b/spec/services/remove_unverified_users_spec.rb
@@ -26,15 +26,13 @@ RSpec.describe RemoveUnverifiedUsers do
 
   subject(:service) do
     described_class.new(
-      client: client,
-      user_pool_id: user_pool_id,
+      adapter: adapter,
       group_id: group_id,
       cutoff_time: cutoff_time,
     )
   end
 
-  let(:client) { instance_double(Aws::CognitoIdentityProvider::Client) }
-  let(:user_pool_id) { "test-pool" }
+  let(:adapter) { instance_double(CognitoServiceAdapter) }
   let(:group_id) { "myott" }
   let(:cutoff_time) { 1.day.ago }
 
@@ -44,7 +42,7 @@ RSpec.describe RemoveUnverifiedUsers do
 
   context "when the user is older than one day and unverified" do
     before do
-      allow(client).to receive(:list_users).and_return(
+      allow(adapter).to receive(:list_users).and_return(
         stub_list_users_response(
           users: [build_user(age: 2.days.ago, username: "old_unverified", email_verified: "false")],
         ),
@@ -60,7 +58,7 @@ RSpec.describe RemoveUnverifiedUsers do
 
   context "when the user is old but verified" do
     before do
-      allow(client).to receive(:list_users).and_return(
+      allow(adapter).to receive(:list_users).and_return(
         stub_list_users_response(
           users: [build_user(age: 2.days.ago, username: "old_verified", email_verified: "true")],
         ),
@@ -76,7 +74,7 @@ RSpec.describe RemoveUnverifiedUsers do
 
   context "when the user is new and unverified" do
     before do
-      allow(client).to receive(:list_users).and_return(
+      allow(adapter).to receive(:list_users).and_return(
         stub_list_users_response(
           users: [build_user(age: 6.hours.ago, username: "new_unverified", email_verified: "false")],
         ),
@@ -92,7 +90,7 @@ RSpec.describe RemoveUnverifiedUsers do
 
   context "when Cognito returns multiple pages" do
     before do
-      allow(client).to receive(:list_users).and_return(
+      allow(adapter).to receive(:list_users).and_return(
         stub_list_users_response(
           users: [build_user(age: 2.days.ago, username: "old_unverified_1", email_verified: "false")],
           pagination_token: "next-token",


### PR DESCRIPTION
## What:
Replace the raw `client:` / `user_pool_id:` constructor args in `RemoveUnverifiedUsers` with an injected `CognitoServiceAdapter`, delegating `list_users` to it.

## Why:
`RemoveUnverifiedUsers` was holding its own raw Cognito SDK client alongside `User.destroy`, which uses `CognitoServiceAdapter` internally — two Cognito clients in flight for a single operation, bypassing the adapter abstraction everything else uses. This makes the architecture consistent and removes the raw SDK dependency from this service.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2463

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Pure refactor with no behaviour change — `CognitoServiceAdapter#list_users` already calls the same underlying SDK method with the same arguments. All existing tests pass and cover the same scenarios.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems)
- Copy changes to sign-in UI (labels, hint text, error messages) with no logic change
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Logging improvements or additional audit trail entries (additive only)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to session handling, cookie attributes, or token lifetimes
- Modifications to the sign-in or sign-out flow (redirects, callbacks, error paths)
- Changes to how user attributes or claims are mapped, stored, or forwarded to downstream services
- New or modified OAuth 2.0 / OIDC scopes, grant types, or client configurations
- Adding or changing feature flags that affect live authentication journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating an endpoint or claim that may still be consumed by another service

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Any change to password hashing, token signing, or cryptographic primitives
- Modifications to MFA logic, step-up authentication, or account recovery flows
- Changes to how user accounts are created, merged, suspended, or deleted
- Changes to authorisation rules, role definitions, or permission scoping
- Secrets rotation or changes to how credentials, signing keys, or client secrets are stored or accessed
- Changes to production AWS infrastructure that cannot be easily rolled back (e.g. Cognito user pool settings, KMS key policy, removal of resources)
- Significant architectural shifts (e.g. new identity provider integrations, changes to the token issuance pipeline)
- Any change that could result in users being locked out of the service or losing access to their accounts