### PR TITLE
Fix failing test for refresh token

### DIFF
--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -125,9 +125,9 @@ RSpec.describe "Sessions", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "logs error when token refresh raises an unexpected error" do
+      it "logs error when token refresh raises an unexpected AWS service error" do
         allow(CognitoTokenVerifier).to receive(:call).and_return(:expired)
-        allow(cognito).to receive(:get_tokens_from_refresh_token).and_raise(StandardError.new("unexpected"))
+        allow(cognito).to receive(:get_tokens_from_refresh_token).and_raise(Aws::Errors::ServiceError.new(nil, "unexpected"))
         allow(Rails.logger).to receive(:error)
         get new_session_path, params: { consumer_id: consumer.id }
         expect(Rails.logger).to have_received(:error).with(/Token refresh failed/)


### PR DESCRIPTION
## What:
 Update the "logs error when token refresh raises an unexpected error" test in sessions_spec.rb to raise `Aws::Errors::ServiceError` instead of a generic `StandardError`         

## Why:

Commit 3caeced ("fix: replace broad rescue StandardError with specific AWS error handling") narrowed `SessionsController#refresh_session_with_token'` rescue clause from `StandardError` to `Aws::Errors::ServiceError`, but didn't update this test — it still stubbed a plain StandardError to simulate "any unexpected error." Since a plain `StandardError `is no longer caught by the narrowed rescue, the stubbed error propagated uncaught instead of being logged, failing the test. This updates the stub to a realistic `Aws::Errors::ServiceError`, matching intentionally narrowed production code actually catches. 

## Ticket:


N/A

## Risk:

**Risk level:** 🟢  Green

**Reason for rating:**
 Test-only change, no production code is modified, and the diff only aligns test expectations with already-committed, already-shipped controller behavior
───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────

- New tests or improved test coverage with no production code changes
- Dependency bumps with no API changes (minor/patch gems)
- Copy changes to sign-in UI (labels, hint text, error messages) with no logic change
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- Terraform formatting or variable renaming with no resource recreation
- Logging improvements or additional audit trail entries (additive only)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────

- Changes to session handling, cookie attributes, or token lifetimes
- Modifications to the sign-in or sign-out flow (redirects, callbacks, error paths)
- Changes to how user attributes or claims are mapped, stored, or forwarded to downstream services
- New or modified OAuth 2.0 / OIDC scopes, grant types, or client configurations
- Adding or changing feature flags that affect live authentication journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- Removing or deprecating an endpoint or claim that may still be consumed by another service

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────

- Any change to password hashing, token signing, or cryptographic primitives
- Modifications to MFA logic, step-up authentication, or account recovery flows
- Changes to how user accounts are created, merged, suspended, or deleted
- Changes to authorisation rules, role definitions, or permission scoping
- Secrets rotation or changes to how credentials, signing keys, or client secrets are stored or accessed
- Changes to production AWS infrastructure that cannot be easily rolled back (e.g. Cognito user pool settings, KMS key policy, removal of resources)
- Significant architectural shifts (e.g. new identity provider integrations, changes to the token issuance pipeline)
- Any change that could result in users being locked out of the service or losing access to their accounts
