### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.bundle
+.direnv
+.git
+.github
+.nix
+.ruby-lsp
+coverage
+log
+spec
+terraform
+tmp
+vendor/bundle


### PR DESCRIPTION
## What
Adds a `.dockerignore` to reduce image size when building

## Why
Saves space and time, especially in dev stack where this adds up running multiple applications

## Risk

**Risk level:** 🟢

**Reason for rating:**
Only ignores stuff we don't need in production