### PR TITLE
feat(HMRC-2609): add GOV.UK Notify delivery receipt callback endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby file: ".ruby-version"
 
 gem "rails", "~> 8.1.3"
 
+gem "aws-sdk-cloudwatch"
 gem "aws-sdk-cognitoidentityprovider"
 gem "bootsnap", require: false
 gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1277.0)
+    aws-sdk-cloudwatch (1.145.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-cognitoidentityprovider (1.149.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
@@ -371,6 +374,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-cloudwatch
   aws-sdk-cognitoidentityprovider
   bootsnap
   brakeman

--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class NotifyCallbacksController < ActionController::API
-  METRIC_NAMESPACE = 'TradeTariff/Notify'
+  METRIC_NAMESPACE = "TradeTariff/Notify".freeze
   FAILURE_STATUSES = %w[permanent-failure technical-failure].freeze
 
   before_action :verify_notify_token
@@ -12,10 +12,10 @@ class NotifyCallbacksController < ActionController::API
 private
 
   def verify_notify_token
-    expected = ENV.fetch('NOTIFY_CALLBACK_BEARER_TOKEN', '')
+    expected = ENV.fetch("NOTIFY_CALLBACK_BEARER_TOKEN", "")
     return head :forbidden if expected.blank?
 
-    provided = request.headers['Authorization'].to_s.delete_prefix('Bearer ')
+    provided = request.headers["Authorization"].to_s.delete_prefix("Bearer ")
     head :forbidden unless ActiveSupport::SecurityUtils.secure_compare(provided, expected)
   end
 
@@ -23,12 +23,12 @@ private
     Aws::CloudWatch::Client.new.put_metric_data(
       namespace: METRIC_NAMESPACE,
       metric_data: [{
-        metric_name: 'DeliveryFailures',
+        metric_name: "DeliveryFailures",
         value: 1,
-        unit: 'Count',
+        unit: "Count",
         dimensions: [
-          { name: 'Environment', value: Rails.env },
-          { name: 'Pipeline', value: 'identity' },
+          { name: "Environment", value: Rails.env },
+          { name: "Pipeline", value: "identity" },
         ],
       }],
     )

--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -27,7 +27,7 @@ private
         value: 1,
         unit: "Count",
         dimensions: [
-          { name: "Environment", value: Rails.env },
+          { name: "Environment", value: ENV.fetch('ENVIRONMENT', 'local') },
           { name: "Pipeline", value: "identity" },
         ],
       }],

--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -27,7 +27,7 @@ private
         value: 1,
         unit: "Count",
         dimensions: [
-          { name: "Environment", value: ENV.fetch('ENVIRONMENT', 'local') },
+          { name: "Environment", value: ENV.fetch("ENVIRONMENT", "local") },
           { name: "Pipeline", value: "identity" },
         ],
       }],

--- a/app/controllers/notify_callbacks_controller.rb
+++ b/app/controllers/notify_callbacks_controller.rb
@@ -1,0 +1,38 @@
+class NotifyCallbacksController < ActionController::API
+  METRIC_NAMESPACE = 'TradeTariff/Notify'
+  FAILURE_STATUSES = %w[permanent-failure technical-failure].freeze
+
+  before_action :verify_notify_token
+
+  def create
+    put_cloudwatch_metric if FAILURE_STATUSES.include?(params[:status])
+    head :ok
+  end
+
+private
+
+  def verify_notify_token
+    expected = ENV.fetch('NOTIFY_CALLBACK_BEARER_TOKEN', '')
+    return head :forbidden if expected.blank?
+
+    provided = request.headers['Authorization'].to_s.delete_prefix('Bearer ')
+    head :forbidden unless ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+  end
+
+  def put_cloudwatch_metric
+    Aws::CloudWatch::Client.new.put_metric_data(
+      namespace: METRIC_NAMESPACE,
+      metric_data: [{
+        metric_name: 'DeliveryFailures',
+        value: 1,
+        unit: 'Count',
+        dimensions: [
+          { name: 'Environment', value: Rails.env },
+          { name: 'Pipeline', value: 'identity' },
+        ],
+      }],
+    )
+  rescue Aws::Errors::ServiceError => e
+    Rails.logger.error("notify_cloudwatch_metric_failed: #{e.class.name}: #{e.message}")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   get "/healthcheck", to: "healthcheck#check"
   get "/healthcheckz", to: "healthcheck#checkz"
 
+  post "notify/callback", to: "notify_callbacks#create", defaults: { format: "json" }
+
   namespace :api, defaults: { format: 'json' } do
     resources :users, only: %i[show destroy]
     post "client_credentials", to: "client_credentials#create"

--- a/spec/requests/notify_callbacks_spec.rb
+++ b/spec/requests/notify_callbacks_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "POST /notify/callback", type: :request do
   let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
 
   before do
-    stub_const("ENV", ENV.to_h.merge("NOTIFY_CALLBACK_BEARER_TOKEN" => bearer_token))
+    stub_const("ENV", ENV.to_h.merge("NOTIFY_CALLBACK_BEARER_TOKEN" => bearer_token, "ENVIRONMENT" => Rails.env))
     allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
     allow(cloudwatch_client).to receive(:put_metric_data)
   end
@@ -54,7 +54,7 @@ RSpec.describe "POST /notify/callback", type: :request do
           value: 1,
           unit: "Count",
           dimensions: [
-            { name: "Environment", value: Rails.env },
+            { name: "Environment", value: ENV.fetch("ENVIRONMENT", "local") },
             { name: "Pipeline", value: "identity" },
           ],
         }],

--- a/spec/requests/notify_callbacks_spec.rb
+++ b/spec/requests/notify_callbacks_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe "POST /notify/callback", type: :request do
   end
 
   context "with a valid bearer token" do
+    let(:expected_metric) do
+      {
+        namespace: "TradeTariff/Notify",
+        metric_data: [{
+          metric_name: "DeliveryFailures",
+          value: 1,
+          unit: "Count",
+          dimensions: [
+            { name: "Environment", value: Rails.env },
+            { name: "Pipeline", value: "identity" },
+          ],
+        }],
+      }
+    end
+
     %w[permanent-failure technical-failure].each do |status|
       it "returns 200 for #{status}" do
         post_callback(status:)
@@ -54,43 +69,51 @@ RSpec.describe "POST /notify/callback", type: :request do
 
       it "emits a CloudWatch DeliveryFailures metric for #{status}" do
         post_callback(status:)
-        expect(cloudwatch_client).to have_received(:put_metric_data).with(
-          namespace: "TradeTariff/Notify",
-          metric_data: [{
-            metric_name: "DeliveryFailures",
-            value: 1,
-            unit: "Count",
-            dimensions: [
-              { name: "Environment", value: Rails.env },
-              { name: "Pipeline", value: "identity" },
-            ],
-          }],
-        )
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(expected_metric)
       end
     end
 
-    it "returns 200 for temporary-failure without emitting a metric" do
-      post_callback(status: "temporary-failure")
-      expect(response).to have_http_status(:ok)
-      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    context "when status is temporary-failure" do
+      it "returns 200" do
+        post_callback(status: "temporary-failure")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not emit a metric" do
+        post_callback(status: "temporary-failure")
+        expect(cloudwatch_client).not_to have_received(:put_metric_data)
+      end
     end
 
-    it "returns 200 for delivered without emitting a metric" do
-      post_callback(status: "delivered")
-      expect(response).to have_http_status(:ok)
-      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    context "when status is delivered" do
+      it "returns 200" do
+        post_callback(status: "delivered")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not emit a metric" do
+        post_callback(status: "delivered")
+        expect(cloudwatch_client).not_to have_received(:put_metric_data)
+      end
     end
 
-    it "returns 200 even when CloudWatch raises a service error" do
-      allow(cloudwatch_client).to receive(:put_metric_data).and_raise(
-        Aws::CloudWatch::Errors::ServiceError.new(nil, "throttled"),
-      )
-      allow(Rails.logger).to receive(:error)
+    context "when CloudWatch raises a service error" do
+      before do
+        allow(cloudwatch_client).to receive(:put_metric_data).and_raise(
+          Aws::CloudWatch::Errors::ServiceError.new(nil, "throttled"),
+        )
+        allow(Rails.logger).to receive(:error)
+      end
 
-      post_callback(status: "permanent-failure")
+      it "returns 200" do
+        post_callback(status: "permanent-failure")
+        expect(response).to have_http_status(:ok)
+      end
 
-      expect(response).to have_http_status(:ok)
-      expect(Rails.logger).to have_received(:error).with(a_string_including("notify_cloudwatch_metric_failed"))
+      it "logs the error" do
+        post_callback(status: "permanent-failure")
+        expect(Rails.logger).to have_received(:error).with(a_string_including("notify_cloudwatch_metric_failed"))
+      end
     end
   end
 end

--- a/spec/requests/notify_callbacks_spec.rb
+++ b/spec/requests/notify_callbacks_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe "POST /notify/callback", type: :request do
+  let(:bearer_token) { "test-notify-bearer-token" }
+  let(:valid_headers) { { "Authorization" => "Bearer #{bearer_token}" } }
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
+
+  before do
+    stub_const("ENV", ENV.to_h.merge("NOTIFY_CALLBACK_BEARER_TOKEN" => bearer_token))
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
+  end
+
+  def post_callback(status:, headers: valid_headers)
+    post notify_callback_path, params: { status: }, as: :json, headers:
+  end
+
+  context "when the bearer token is missing" do
+    it "returns 403" do
+      post_callback(status: "permanent-failure", headers: {})
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "does not emit a metric" do
+      post_callback(status: "permanent-failure", headers: {})
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+  end
+
+  context "when the bearer token is wrong" do
+    it "returns 403" do
+      post_callback(status: "permanent-failure", headers: { "Authorization" => "Bearer wrong-token" })
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context "when the NOTIFY_CALLBACK_BEARER_TOKEN env var is not set" do
+    before do
+      stub_const("ENV", ENV.to_h.reject { |k, _| k == "NOTIFY_CALLBACK_BEARER_TOKEN" })
+    end
+
+    it "returns 403 regardless of the provided token" do
+      post_callback(status: "permanent-failure")
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  context "with a valid bearer token" do
+    %w[permanent-failure technical-failure].each do |status|
+      it "returns 200 for #{status}" do
+        post_callback(status:)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "emits a CloudWatch DeliveryFailures metric for #{status}" do
+        post_callback(status:)
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: "TradeTariff/Notify",
+          metric_data: [{
+            metric_name: "DeliveryFailures",
+            value: 1,
+            unit: "Count",
+            dimensions: [
+              { name: "Environment", value: Rails.env },
+              { name: "Pipeline", value: "identity" },
+            ],
+          }],
+        )
+      end
+    end
+
+    it "returns 200 for temporary-failure without emitting a metric" do
+      post_callback(status: "temporary-failure")
+      expect(response).to have_http_status(:ok)
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+
+    it "returns 200 for delivered without emitting a metric" do
+      post_callback(status: "delivered")
+      expect(response).to have_http_status(:ok)
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+
+    it "returns 200 even when CloudWatch raises a service error" do
+      allow(cloudwatch_client).to receive(:put_metric_data).and_raise(
+        Aws::CloudWatch::Errors::ServiceError.new(nil, "throttled"),
+      )
+      allow(Rails.logger).to receive(:error)
+
+      post_callback(status: "permanent-failure")
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).to have_received(:error).with(a_string_including("notify_cloudwatch_metric_failed"))
+    end
+  end
+end

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -8,7 +8,8 @@ data "aws_iam_policy_document" "task" {
       "ssmmessages:OpenDataChannel",
       "logs:CreateLogStream",
       "logs:DescribeLogStreams",
-      "logs:PutLogEvents"
+      "logs:PutLogEvents",
+      "cloudwatch:PutMetricData",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## What:
Adds `POST /notify/callback` — a webhook endpoint that GOV.UK Notify calls when delivery status changes for emails sent by the Identity service's Cognito Lambda. The endpoint verifies Notify's bearer token and emits a `TradeTariff/Notify / DeliveryFailures` CloudWatch metric for `permanent-failure` and `technical-failure` statuses.

## Why:
The backend already polls Notify for delivery status and emits these metrics (HMRC-2609). Identity sends OTP emails via a standalone Cognito Lambda that has no polling mechanism, so callbacks are the right approach here. The metric feeds the existing `notify-delivery-failures-production` alarm (no new Terraform alarm needed — the alarm watches the namespace without a Pipeline dimension filter, so it covers all pipelines including `identity`).

`temporary-failure` is excluded from the metric as it may self-resolve.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2609

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Adds a new unauthenticated-ish public endpoint (secured by a Notify bearer token rather than our internal API tokens) and new IAM permissions (`cloudwatch:PutMetricData`). The endpoint is purely additive and read-only from a data perspective, but IAM permission changes warrant a team conversation first.

**Manual steps required before this is useful:**
1. Add `NOTIFY_CALLBACK_BEARER_TOKEN` to the `identity-configuration` Secrets Manager secret
2. Configure the callback URL (`https://<identity-host>/notify/callback`) in the GOV.UK Notify dashboard for the Identity service